### PR TITLE
feat(doc): add docker commands for server run(for easy copy-paste)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,21 @@ Please check existing issues (both open and closed) before creating new ones. It
 
 `docker run ghcr.io/arriven/db1000n`
 
+у випадку запуску на сервері можете використовувати цю команду:
+```
+docker run --restart=always --name=db1000n --detach --pull=always ghcr.io/arriven/db1000n:latest
+```
+
+де:
+
+`--restart=always` - перезапуск після помилки абощо
+
+`--name=desinform_stop` - присвоєння імені контейнеру
+
+`--detach` - запуск в окремому процесі
+
+` --pull=always` - оновлення образу перед запуском
+
 ### Що робити далі
 
 Вам потрібно лише тримати увімкненим VPN, свій ком’ютер і цю програму на ньому.
@@ -57,6 +72,21 @@ Switch to Russia if possible. Don’t use Ukraine as VPN location! But any other
 
 `docker run ghcr.io/arriven/db1000n`
 
+or use this command in case of running on servers:
+```
+docker run --restart=always --name=db1000n --detach --pull=always ghcr.io/arriven/db1000n:latest
+```
+
+where:
+
+`--restart=always` - restart after exit
+
+`--name=desinform_stop` - assign a name to the container
+
+`--detach` - run in separate process
+
+` --pull=always` - pull image before running
+
 ### What’s next
 
 You need to keep your computer active, use VPN and make sure that the application is up and running.
@@ -71,7 +101,6 @@ The software is provided as is under no guarantee.
 I will update both the repo and this readme as I go during following days (date of writing this is 26th of February 2022, third day into russian invasion into Ukraine)
 
 Synflood implementation is taken from https://github.com/bilalcaliskan/syn-flood and slightly patched. I couldn't just import the package as all the functionality code was in an internal package preventing import into other modules. Will figure it out better later (sorry to the owner).
-
 ## How to install
 
 ### binary install


### PR DESCRIPTION
tune readme to have easy copy-paste command for server run 

Also there is memory leak and therefore restart=always is required 
<img width="766" alt="Screenshot 2022-03-04 at 20 49 13" src="https://user-images.githubusercontent.com/32264674/156824090-4d4c63e1-45e5-406f-8980-19dd93dcd6c0.png">
