### PR TITLE
Allow specifying username and password in config itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,12 +149,28 @@ if you don't want to use VPN from within docker container, set `--env "VPN_ENABL
 if you want to to use VPN from within docker container:
 
 - place your `.ovpn` or `.conf` files into `openvpn/` directory
+- if there's more than one `.ovpn` or `.conf` file, random configuration will be picked
 - set `--env "VPN_ENABLED=true` in `run.sh`
 - update `--env "OPENVPN_USERNAME="` and `--env "OPENVPN_PASSWORD="` in `run.sh` with your credentials
 
 ```bash
 ./run.sh
 ```
+
+if you want to use different VPN providers (meaning different `OPENVPN_USERNAME` and `OPENVPN_PASSWORD` credentials), do the following:
+
+- set `--env "VPN_ENABLED=true` in `run.sh`
+- remove `--env "OPENVPN_USERNAME="` and `--env "OPENVPN_PASSWORD="` from `run.sh`
+- place your `openvpn-provider-1.conf` into `openvpn/` directory
+- find the line in your `openvpn-provider-1.conf` where it says `auth-user-pass` and replace with `auth-user-pass provider1.txt`
+- create a text file in `openvpn/provider1.txt` with two lines:
+
+```
+<your provider 1 username>
+<your provider 1 password>
+```
+
+- repeat steps above for multiple providers
 
 ### kubernetes install
 

--- a/run/run-openvpn.sh
+++ b/run/run-openvpn.sh
@@ -2,34 +2,34 @@
 
 set -e
 
-# prepare vpn
-mkdir -p /dev/net
-if [ ! -c /dev/net/tun ]; then
-	mknod /dev/net/tun c 10 200
-fi
-
-readonly OVPNCONF_DIR="/etc/openvpn_host"
-
-# Move the config over to a tmp file and inject the credentials in
-OPENVPN_CONF="$(mktemp).ovpn"
-readonly OPENVPN_CONF
-
-if [[ -n "$OPENVPN_USERNAME" ]] || [[ -n "$OPENVPN_PASSWORD" ]]
-then
-	readonly OPENVPN_AUTH_USER_PASS="$(mktemp)_credentials.conf"
-	echo -e "$OPENVPN_USERNAME\n$OPENVPN_PASSWORD" > "$OPENVPN_AUTH_USER_PASS"
-	chmod 400 $OPENVPN_AUTH_USER_PASS
-
-	grep -Ev "(^(up|down)\s|auth-user-pass)" \
-	  "$(ls $OVPNCONF_DIR/*.conf $OVPNCONF_DIR/*.ovpn | shuf -n 1)" > "$OPENVPN_CONF"
-	echo "auth-user-pass $OPENVPN_AUTH_USER_PASS" >> "$OPENVPN_CONF"
-else
-	grep -Ev "(^(up|down)\s)" \
-	  "$(ls $OVPNCONF_DIR/*.conf $OVPNCONF_DIR/*.ovpn | shuf -n 1)" > "$OPENVPN_CONF"
-fi
-
 if [[ -n "$VPN_ENABLED" ]]
 then
+  # prepare vpn
+  mkdir -p /dev/net
+  if [ ! -c /dev/net/tun ]; then
+  	mknod /dev/net/tun c 10 200
+  fi
+
+  readonly OVPNCONF_DIR="/etc/openvpn_host"
+
+  # Move the config over to a tmp file and inject the credentials in
+  OPENVPN_CONF="$(mktemp).ovpn"
+  readonly OPENVPN_CONF
+
+  if [[ -n "$OPENVPN_USERNAME" ]] || [[ -n "$OPENVPN_PASSWORD" ]]
+  then
+  	readonly OPENVPN_AUTH_USER_PASS="$(mktemp)_credentials.conf"
+  	echo -e "$OPENVPN_USERNAME\n$OPENVPN_PASSWORD" > "$OPENVPN_AUTH_USER_PASS"
+  	chmod 400 $OPENVPN_AUTH_USER_PASS
+
+  	grep -Ev "(^(up|down)\s|auth-user-pass)" \
+  	  "$(ls $OVPNCONF_DIR/*.conf $OVPNCONF_DIR/*.ovpn | shuf -n 1)" > "$OPENVPN_CONF"
+  	echo "auth-user-pass $OPENVPN_AUTH_USER_PASS" >> "$OPENVPN_CONF"
+  else
+  	grep -Ev "(^(up|down)\s)" \
+  	  "$(ls $OVPNCONF_DIR/*.conf $OVPNCONF_DIR/*.ovpn | shuf -n 1)" > "$OPENVPN_CONF"
+  fi
+
   /usr/sbin/openvpn --script-security 2 --up /usr/local/bin/openvpn-up.sh \
     --cd /etc/openvpn_host --config "$OPENVPN_CONF"
 


### PR DESCRIPTION
In current implementation we have to replace `auth-user-pass` line with values that are provided `--env "OPENVPN_USERNAME="` and `--env "OPENVPN_PASSWORD="`.

This works fine if you have a setup where you are using a single VPN provider and multiple `.conf` files, typically representing different countries, and want to rotate between these configurations randomly.

This PR makes it possible to use different VPN providers at the same time by making `OPENVPN_USERNAME` and `OPENVPN_PASSWORD` optional and allowing user to specify credentials manually using `auth-user-pass credentials.txt` in each configuration file.