### PR TITLE
Update 01_db1000n_deployment.yaml

### DIFF
--- a/k8s-manifest/simple/01_db1000n_deployment.yaml
+++ b/k8s-manifest/simple/01_db1000n_deployment.yaml
@@ -17,7 +17,8 @@ spec:
     spec:
       containers:
       - name: db1000n
-        image: ghcr.io/arriven/db1000n
+        image: ghcr.io/arriven/db1000n:latest
+        imagePullPolicy: Always
         resources:
           requests:
             memory: "512Mi"


### PR DESCRIPTION

[Default image pull policy](https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting)

When you (or a controller) submit a new Pod to the API server, your cluster sets the imagePullPolicy field when specific conditions are met:

if you omit the imagePullPolicy field, and the tag for the container image is :latest, imagePullPolicy is automatically set to **Always**;
if you omit the imagePullPolicy field, and you don't specify the tag for the container image, imagePullPolicy is automatically set to Always;
if you omit the imagePullPolicy field, and you specify the tag for the container image that isn't :latest, the imagePullPolicy is automatically set to IfNotPresent.


https://kubernetes.io/docs/concepts/containers/images/