### PR TITLE
added get proxies by url function and proxies url argument

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ package main
 
 import (
 	"flag"
+	"github.com/Arriven/db1000n/src/utils/templates"
 	"os"
 	"os/signal"
 	"syscall"
@@ -36,6 +37,7 @@ import (
 
 func main() {
 	var configPaths string
+	var proxiesURL string
 	var backupConfig string
 	var refreshTimeout time.Duration
 	var logLevel logs.Level
@@ -47,6 +49,7 @@ func main() {
 	flag.IntVar(&logLevel, "l", logs.Info, "logging level. 0 - Debug, 1 - Info, 2 - Warning, 3 - Error")
 	flag.BoolVar(&help, "h", false, "print help message and exit")
 	flag.StringVar(&metricsPath, "m", "", "path where to dump usage metrics, can be URL or file, empty to disable")
+	flag.StringVar(&proxiesURL, "p", "", "url to fetch proxies list")
 	flag.Parse()
 
 	if help {
@@ -57,6 +60,10 @@ func main() {
 	logs.Default = logs.New(logLevel)
 
 	l := logs.New(logLevel)
+
+	if proxiesURL != "" {
+		templates.SetProxiesUrl(proxiesURL)
+	}
 
 	r, err := runner.New(&runner.Config{
 		ConfigPaths:    configPaths,

--- a/src/utils/templates/templates.go
+++ b/src/utils/templates/templates.go
@@ -15,25 +15,32 @@ import (
 	"github.com/Arriven/db1000n/src/packetgen"
 )
 
+var proxiesURL = "https://raw.githubusercontent.com/Arriven/db1000n/main/proxylist.json"
+
 func getProxylistURL() string {
-	return "https://raw.githubusercontent.com/Arriven/db1000n/main/proxylist.json"
+	return proxiesURL
+}
+
+func SetProxiesUrl(url string) {
+	proxiesURL = url
 }
 
 func getProxylist() (urls []string) {
-	resp, err := http.Get(getProxylistURL())
+	return getProxylistByUrl(getProxylistURL())
+}
+
+func getProxylistByUrl(url string) (urls []string) {
+	resp, err := http.Get(url)
 	if err != nil {
 		return nil
 	}
-
 	defer resp.Body.Close()
-
-	if err = json.NewDecoder(resp.Body).Decode(&urls); err != nil {
+	err = json.NewDecoder(resp.Body).Decode(&urls)
+	if err != nil {
 		return nil
 	}
-
 	return urls
 }
-
 func getURLContent(url string) (string, error) {
 	resp, err := http.Get(url)
 	if err != nil {
@@ -56,25 +63,27 @@ func randomUUID() string {
 
 func Execute(input string) string {
 	funcMap := template.FuncMap{
-		"random_uuid":     randomUUID,
-		"random_int_n":    rand.Intn,
-		"random_int":      rand.Int,
-		"random_payload":  packetgen.RandomPayload,
-		"random_ip":       packetgen.RandomIP,
-		"random_port":     packetgen.RandomPort,
-		"random_mac_addr": packetgen.RandomMacAddr,
-		"local_ip":        packetgen.LocalIP,
-		"local_mac_addr":  packetgen.LocalMacAddres,
-		"base64_encode":   base64.StdEncoding.EncodeToString,
-		"base64_decode":   base64.StdEncoding.DecodeString,
-		"json_encode":     json.Marshal,
-		"json_decode":     json.Unmarshal,
-		"get_url":         getURLContent,
-		"proxylist_url":   getProxylistURL,
-		"get_proxylist":   getProxylist,
+		"random_uuid":          randomUUID,
+		"random_int_n":         rand.Intn,
+		"random_int":           rand.Int,
+		"random_payload":       packetgen.RandomPayload,
+		"random_ip":            packetgen.RandomIP,
+		"random_port":          packetgen.RandomPort,
+		"random_mac_addr":      packetgen.RandomMacAddr,
+		"local_ip":             packetgen.LocalIP,
+		"local_mac_addr":       packetgen.LocalMacAddres,
+		"base64_encode":        base64.StdEncoding.EncodeToString,
+		"base64_decode":        base64.StdEncoding.DecodeString,
+		"json_encode":          json.Marshal,
+		"json_decode":          json.Unmarshal,
+		"get_url":              getURLContent,
+		"proxylist_url":        getProxylistURL,
+		"get_proxylist":        getProxylist,
+		"get_proxylist_by_url": getProxylistByUrl,
 	}
 
 	// TODO: consider adding ability to populate custom data
+	input = strings.Replace(input, "\\", "", -1)
 	tmpl, err := template.New("test").Funcs(funcMap).Parse(input)
 	if err != nil {
 		logs.Default.Warning("error parsing template: %v", err)

--- a/src/utils/templates/templates.go
+++ b/src/utils/templates/templates.go
@@ -35,8 +35,7 @@ func getProxylistByUrl(url string) (urls []string) {
 		return nil
 	}
 	defer resp.Body.Close()
-	err = json.NewDecoder(resp.Body).Decode(&urls)
-	if err != nil {
+	if err = json.NewDecoder(resp.Body).Decode(&urls); err != nil {
 		return nil
 	}
 	return urls


### PR DESCRIPTION
- added templating function `get_proxylist_by_url` to add ability to set separate proxies for each job
- added `p` flag to set generic list of proxies

config example
```
{
      "type": "http",
      "args": {
        "method": "GET",
        "path": "http://riabir.ru:443/",
        "interval_ms": 2,
        "client": {
          "async": true,
          "proxy_urls": "{{ get_proxylist_by_url \"https://test.com/proxylist.json\" }}"
        }
      }
},
```
closes #148 