### PR TITLE
Use last known good config if new config can't be loaded

### DIFF
--- a/src/runner/runner.go
+++ b/src/runner/runner.go
@@ -69,16 +69,16 @@ func (r *Runner) Run() {
 		wg     sync.WaitGroup
 	)
 
-	newRawConfig, err := fetchConfig(r.configPaths, r.log)
-	if err != nil {
-		newRawConfig = r.backupConfig
-	}
-
 	for !stop {
-		newRawConfig, err = fetchConfig(r.configPaths, r.log)
+		newRawConfig, err := fetchConfig(r.configPaths, r.log)
 		if err != nil {
-			newRawConfig = r.currentRawConfig
-			r.log.Warning("Could not load new config, proceeding with last known good config")
+			if r.currentRawConfig != nil {
+				r.log.Warning("Could not load new config, proceeding with last known good config")
+				newRawConfig = r.currentRawConfig
+			} else {
+				r.log.Warning("Could not load new config, proceeding with backupConfig")
+				newRawConfig = r.backupConfig
+			}
 		}
 
 		if !bytes.Equal(r.currentRawConfig, newRawConfig) { // Only restart jobs if the new config differs from the current one

--- a/src/runner/runner.go
+++ b/src/runner/runner.go
@@ -69,10 +69,16 @@ func (r *Runner) Run() {
 		wg     sync.WaitGroup
 	)
 
+	newRawConfig, err := fetchConfig(r.configPaths, r.log)
+	if err != nil {
+		newRawConfig = r.backupConfig
+	}
+
 	for !stop {
-		newRawConfig, err := fetchConfig(r.configPaths, r.log)
+		newRawConfig, err = fetchConfig(r.configPaths, r.log)
 		if err != nil {
-			newRawConfig = r.backupConfig
+			newRawConfig = r.currentRawConfig
+			r.log.Warning("Could not load new config, proceeding with last known good config")
 		}
 
 		if !bytes.Equal(r.currentRawConfig, newRawConfig) { // Only restart jobs if the new config differs from the current one


### PR DESCRIPTION
Sometimes you get EOF errors while trying to update job definitions:

```
[INFO]  2022/03/06 01:37:50 [INFO] Loading config from "https://raw.githubusercontent.com/db1000n-coordinators/LoadTestConfig/main/config.json"
[WARN]  2022/03/06 01:37:50 [WARN] Failed to fetch config from "https://raw.githubusercontent.com/db1000n-coordinators/LoadTestConfig/main/config.json": Get "https://raw.githubusercontent.com/db1000n-coordinators/LoadTestConfig/main/config.json": unexpected EOF
```

Proposal is to fallback to `backupConfig` only when we get an error on the first start; otherwise use last known good configuration:

```
[INFO]  2022/03/06 01:37:50 [INFO] Loading config from "https://raw.githubusercontent.com/db1000n-coordinators/LoadTestConfig/main/config.json"
[WARN]  2022/03/06 01:37:50 [WARN] Failed to fetch config from "https://raw.githubusercontent.com/db1000n-coordinators/LoadTestConfig/main/config.json": Get "https://raw.githubusercontent.com/db1000n-coordinators/LoadTestConfig/main/config.json": unexpected EOF
[INFO]  2022/03/06 01:37:50 [INFO] Could not load new config, proceeding with last known good config
```