### PR TITLE
- Change DNS job to accept domain name instead of NS IP.

### DIFF
--- a/src/dnsblast/README.md
+++ b/src/dnsblast/README.md
@@ -9,8 +9,7 @@ Sends DNS queries with QType set to 'A'.
 
 ## Job parameters
 
-* `target_server_ip` - Target server IP address (no default value)
-* `target_server_port` - Target server port (`53` for UDP & TCP, `853` for TCP-TLS)
+* `root_domain` - Root domain to use which will be queried for nameservers
 * `protocol` - DNS net. protocol (`udp` as default, [`udp`, `tcp`, `tcp-tls`] supported)
 * `seed_domains` - Domain names to use as base of DNS query (no default, at least one required, like `yahoo.com`)
 * `parallel_queries` - Number of DNS queries to send between delays

--- a/src/dnsblast/dns-blast_test.go
+++ b/src/dnsblast/dns-blast_test.go
@@ -27,8 +27,8 @@ func TestBlast(t *testing.T) {
 	var (
 		blastContext, cancel = context.WithTimeout(context.Background(), testDuration)
 		config               = &Config{
-			TargetServerHostPort: net.JoinHostPort(testServer, strconv.Itoa(testPort)),
-			Protocol:             testProto,
+			RootDomain: net.JoinHostPort(testServer, strconv.Itoa(testPort)),
+			Protocol:   testProto,
 			SeedDomains: []string{
 				domainA,
 				domainB,


### PR DESCRIPTION
  Job will query NS servers for this domain and send requests to all NS.
- Removed "port" option, since all target services uses standard ports