### PR TITLE
Add VPN_CONFIG_PATTERN to be able to do random VPN selection

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
 version: "3"
 
 services:
-  # creates OpenVPN Docker container to first provider, endpoint #1
+  # creates OpenVPN Docker container to first provider that randomly picks .conf file
   ovpn_01:
-    image: ghcr.io/wfg/openvpn-client
+    image: ghcr.io/wfg/openvpn-client:2.1.0
     cap_add:
       - NET_ADMIN
     security_opt:
@@ -18,13 +18,13 @@ services:
       KILL_SWITCH: "on"
       HTTP_PROXY: "off"
       VPN_AUTH_SECRET: provider01_secret
-      VPN_CONFIG_FILE: provider01.endpoint01.conf
+      VPN_CONFIG_PATTERN: provider01*.conf # this will match provider01_country01.conf, provider01_country02.conf etc
     secrets:
       - provider01_secret
 
-  # creates OpenVPN Docker container to first provider, endpoint #2
+  # creates OpenVPN Docker container to first provider with specific .conf file
   ovpn_02:
-    image: ghcr.io/wfg/openvpn-client
+    image: ghcr.io/wfg/openvpn-client:2.1.0
     cap_add:
       - NET_ADMIN
     security_opt:
@@ -39,13 +39,13 @@ services:
       KILL_SWITCH: "on"
       HTTP_PROXY: "off"
       VPN_AUTH_SECRET: provider01_secret
-      VPN_CONFIG_FILE: provider01.endpoint02.conf
+      VPN_CONFIG_FILE: provider01.endpoint02.conf # will use only this .conf file
     secrets:
       - provider01_secret
 
-  # creates OpenVPN Docker container to second provider, endpoint #1
+  # creates OpenVPN Docker container to second provider with specific .conf file
   ovpn_03:
-    image: ghcr.io/wfg/openvpn-client
+    image: ghcr.io/wfg/openvpn-client:2.1.0
     cap_add:
       - NET_ADMIN
     security_opt:
@@ -60,7 +60,7 @@ services:
       KILL_SWITCH: "on"
       HTTP_PROXY: "off"
       VPN_AUTH_SECRET: provider02_secret
-      VPN_CONFIG_FILE: provider02.endpoint01.conf
+      VPN_CONFIG_FILE: provider02.endpoint01.conf # will use only this .conf file
     secrets:
       - provider02_secret
 


### PR DESCRIPTION
# Description

I've made a couple of changes to `wfg/docker-openvpn-client` docker image that were successfully merged into main branch and got released as `v2.1.0`:

https://github.com/wfg/docker-openvpn-client/pull/51
https://github.com/wfg/docker-openvpn-client/pull/52

This allows specifying a pattern to be used for `.conf` matching like this:

```yaml
ovpn_01:
    image: ghcr.io/wfg/openvpn-client:2.1.0
    cap_add:
      - NET_ADMIN
    security_opt:
      - label:disable
    restart: unless-stopped
    volumes:
      - /dev/net:/dev/net:z
      - ./openvpn/:/data/vpn:z
    sysctls:
      - net.ipv6.conf.all.disable_ipv6=1
    environment:
      KILL_SWITCH: "on"
      HTTP_PROXY: "off"
      VPN_AUTH_SECRET: provider01_secret
      VPN_CONFIG_PATTERN: provider01*.conf # this will match provider01_country01.conf, provider01_country02.conf etc
    secrets:
      - provider01_secret
```

Fixes https://github.com/Arriven/db1000n/issues/190

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

* Need to place at least two OpenVPN configuration files into `openvpn/` directory
* Change `docker-compose.yml` to use your authentication values
* Change `docker-compose.yml` and specify correct `VPN_CONFIG_PATTERN`
* `docker-compose up` and `docker-compose down` a couple of times to verify that different `.conf` files are picked up

## Test Configuration

* Release version: N/A
* Platform: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6

## Screenshots

- [x] No screenshot
