### PR TITLE
Refactor TCP-TLS connection to bypass filtering based on SSL fingerprinting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/miekg/dns v1.1.46
 	github.com/mjpitz/go-ga v0.0.7
+	github.com/refraction-networking/utls v1.0.0
 	github.com/schollz/progressbar/v3 v3.8.6
 	golang.org/x/net v0.0.0-20220225172249-27dd8689420f
 )

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/mjpitz/go-ga v0.0.7/go.mod h1:wK4khuRvgPjGD+xzSIOAgetZYO7ma+9uDrwMveD
 github.com/ngdinhtoan/glide-cleanup v0.2.0/go.mod h1:UQzsmiDOb8YV3nOsCxK/c9zPpCZVNoHScRE3EO9pVMM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/refraction-networking/utls v1.0.0 h1:6XQHSjDmeBCF9sPq8p2zMVGq7Ud3rTD2q88Fw8Tz1tA=
+github.com/refraction-networking/utls v1.0.0/go.mod h1:tz9gX959MEFfFN5whTIocCLUG57WiILqtdVxI8c6Wj0=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/schollz/progressbar/v3 v3.8.6 h1:QruMUdzZ1TbEP++S1m73OqRJk20ON11m6Wqv4EoGg8c=

--- a/src/dnsblast/README.md
+++ b/src/dnsblast/README.md
@@ -13,4 +13,15 @@ Sends DNS queries with QType set to 'A'.
 * `protocol` - DNS net. protocol (`udp` as default, [`udp`, `tcp`, `tcp-tls`] supported)
 * `seed_domains` - Domain names to use as base of DNS query (no default, at least one required, like `yahoo.com`)
 * `parallel_queries` - Number of DNS queries to send between delays
-* `interval_ms` - (inherited) delay in MS between query loop iteration 
+* `interval_ms` - (inherited) delay in MS between query loop iteration
+
+# A note from the Author:
+~~~
+Use only to test your own services, do not abuse services that you do not own!
+~~~
+
+Research references:
+* https://www.ietf.org/proceedings/91/slides/slides-91-dprive-5.pdf
+* https://github.com/refraction-networking/utls
+* https://ja3er.com/about.html
+* https://habr.com/ru/post/596411/

--- a/src/dnsblast/dns-blast_test.go
+++ b/src/dnsblast/dns-blast_test.go
@@ -2,49 +2,98 @@ package dnsblast
 
 import (
 	"context"
-	"net"
-	"strconv"
 	"testing"
 	"time"
 )
 
 func TestBlast(t *testing.T) {
 	const (
-		testDuration = 10 * time.Second
+		testDuration = 5 * time.Second
 
-		testServer = "10.8.0.1"
-		testPort   = DefaultDNSPort
-		testProto  = UDPProtoName
-
-		domainA = "cnn.com"
-		domainB = "yahoo.com"
-		domainC = "foxnews.com"
+		testRootDomain = "example.com"
+		seedDomainA    = "cnn.com"
+		seedDomainB    = "yahoo.com"
+		seedDomainC    = "foxnews.com"
 
 		testIterationDelay = 50 * time.Millisecond
 		testParallelism    = 3
 	)
 
-	var (
-		blastContext, cancel = context.WithTimeout(context.Background(), testDuration)
-		config               = &Config{
-			RootDomain: net.JoinHostPort(testServer, strconv.Itoa(testPort)),
-			Protocol:   testProto,
+	type testCase struct {
+		Name     string
+		Duration time.Duration
+
+		RootDomain      string
+		Protocol        string
+		SeedDomains     []string
+		Delay           time.Duration
+		ParallelQueries int
+	}
+
+	testCases := []testCase{
+		{
+			Name:       "Benchmark over UDP",
+			Duration:   testDuration,
+			RootDomain: testRootDomain,
+			Protocol:   UDPProtoName,
 			SeedDomains: []string{
-				domainA,
-				domainB,
-				domainC,
+				seedDomainA,
+				seedDomainB,
+				seedDomainC,
 			},
 			Delay:           testIterationDelay,
 			ParallelQueries: testParallelism,
-		}
-	)
-	defer cancel()
-
-	err := Start(blastContext, config)
-	if err != nil {
-		t.Errorf("failed to start the blaster: %s", err)
-		return
+		},
+		{
+			Name:       "Benchmark over TCP",
+			Duration:   testDuration,
+			RootDomain: testRootDomain,
+			Protocol:   TCPProtoName,
+			SeedDomains: []string{
+				seedDomainA,
+				seedDomainB,
+				seedDomainC,
+			},
+			Delay:           testIterationDelay,
+			ParallelQueries: testParallelism,
+		},
+		{
+			Name:       "Benchmark over TCP-TLS",
+			Duration:   testDuration,
+			RootDomain: testRootDomain,
+			Protocol:   TCPTLSProtoName,
+			SeedDomains: []string{
+				seedDomainA,
+				seedDomainB,
+				seedDomainC,
+			},
+			Delay:           testIterationDelay,
+			ParallelQueries: testParallelism,
+		},
 	}
 
-	time.Sleep(testDuration + time.Second)
+	for i := range testCases {
+		t.Run(testCases[i].Name, func(tt *testing.T) {
+			config := &Config{
+				RootDomain:      testCases[i].RootDomain,
+				Protocol:        testCases[i].Protocol,
+				SeedDomains:     testCases[i].SeedDomains,
+				Delay:           testCases[i].Delay,
+				ParallelQueries: testCases[i].ParallelQueries,
+			}
+
+			tt.Logf("[%s] benchmark configuration: %+v", testCases[i].Name, config)
+
+			blastContext, cancel := context.WithTimeout(context.Background(), testCases[i].Duration)
+			defer cancel()
+
+			err := Start(blastContext, config)
+			if err != nil {
+				tt.Errorf("failed to start the blaster: %s", err)
+				return
+			}
+
+			time.Sleep(testCases[i].Duration + time.Second)
+		})
+	}
 }

--- a/src/jobs/dnsblast.go
+++ b/src/jobs/dnsblast.go
@@ -38,6 +38,11 @@ func dnsBlastJob(ctx context.Context, args Args, debug bool) error {
 	// Default settings and early misconfiguration prevention
 	//
 
+	// Root domain verification
+	if len(jobConfig.RootDomain) == 0 {
+		return errors.New("no root domain provided, consider adding it")
+	}
+
 	// Domain seeds verification
 	if len(jobConfig.SeedDomains) == 0 {
 		return errors.New("no seed domains provided, at least one is required")

--- a/testconfig.json
+++ b/testconfig.json
@@ -52,8 +52,7 @@
     {
       "type": "dns-blast",
       "args": {
-        "target_server_ip": "10.8.0.1",
-        "target_server_port": 53,
+        "root_domain": "example.com",
         "protocol": "udp",
         "seed_domains": ["yahoo.com"],
         "parallel_queries": 3,


### PR DESCRIPTION
# Description

Refactor TCP over TLS connections to bypass SSL fingerprinting. This update brings a refactoring for two benchmarking jobs:
* SlowLoris
* DNSBlast

Research:
* https://habr.com/ru/post/596411/
* https://www.ietf.org/proceedings/91/slides/slides-91-dprive-5.pdf
* https://github.com/refraction-networking/utls
* https://ja3er.com/about.html

~~~
Note from the Author: Use only to test your own services, do not abuse services that you do not own! 
~~~



## Type of change

- [* ] New feature -> Randomized TLS handshake
- [*] Documentation update -> see `src/dnsblast/README.md`

# How Has This Been Tested?
- [*] TestBlast

