### PR TITLE
bring back default for attack env variable

### DIFF
--- a/terraform/azure/bomblet/variables.tf
+++ b/terraform/azure/bomblet/variables.tf
@@ -18,4 +18,6 @@ variable "attack_memory" {
   default = "1.5"
 }
 
-variable "attack_environment_variables" {}
+variable "attack_environment_variables" { 
+  default = {}
+}


### PR DESCRIPTION
# Description

This default was mistakenly removed during docs refactoring.

Fixes #195 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
