### PR TITLE
Added mirrors for config.

### DIFF
--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ func main() {
 	var refreshTimeout time.Duration
 	var debug, help bool
 	var metricsPath string
-	flag.StringVar(&configPaths, "c", "https://raw.githubusercontent.com/db1000n-coordinators/LoadTestConfig/main/config.json", "path to config files, separated by a comma, each path can be a web endpoint")
+	flag.StringVar(&configPaths, "c", "https://raw.githubusercontent.com/db1000n-coordinators/LoadTestConfig/main/config.json,https://gitlab.com/bestdarkstar/LoadTestConfig/-/raw/main/config.json,https://bitbucket.org/bestdark/loadtestconfig/raw/main/config.json", "path to config files, separated by a comma, each path can be a web endpoint")
 	flag.StringVar(&backupConfig, "b", config.DefaultConfig, "raw backup config in case the primary one is unavailable")
 	flag.DurationVar(&refreshTimeout, "r", time.Minute, "refresh timeout for updating the config")
 	flag.BoolVar(&debug, "d", false, "enable debug level logging")


### PR DESCRIPTION
# Description

Added mirrors for config files, in case Russia blocks github, so RU VPN users can still load config

Related to #204
Not closing since we may also add non git mirrors

## Type of change

Added additional links to mirrors of config files

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- When some links are purposufully broken, app correctly falls back to next ones

## Test Configuration

* Release version: 07e552eb9a740c44f88b44704df24e97c8ad6606
* Platform: Windows

## Logs

When all links are correct:
```text
C:\Projects\db1000n>go run main.go
2022/03/07 10:11:10.685127 runner.go:164: Loading config from "https://raw.githubusercontent.com/db1000n-coordinators/LoadTestConfig/main/config.json"
2022/03/07 10:11:10.685127 runner.go:87: New config received, applying
```
When some links are broken:
```text
C:\Projects\db1000n>go run main.go
2022/03/07 10:12:10.914883 runner.go:160: Failed to fetch config from "https://raw.qqqgithubusercontent.com/db1000n-coordinators/LoadTestConfig/main/config.json": Get "https://raw.qqqgithubusercontent.com/db1000n-coordinators/LoadTestConfig/main/config.json": dial tcp: lookup raw.qqqgithubusercontent.com: no such host
2022/03/07 10:12:10.915998 runner.go:160: Failed to fetch config from "https://qqqgitlab.com/bestdarkstar/LoadTestConfig/-/raw/main/config.json": Get "https://qqqgitlab.com/bestdarkstar/LoadTestConfig/-/raw/main/config.json": dial tcp: lookup qqqgitlab.com: no such host
2022/03/07 10:12:11.569429 runner.go:164: Loading config from "https://bitbucket.org/bestdark/loadtestconfig/raw/main/config.json"
2022/03/07 10:12:11.569429 runner.go:87: New config received, applying
```
