### PR TITLE
Changed aws ec2 to spot instances

### DIFF
--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -125,6 +125,9 @@ resource "aws_launch_template" "example" {
   image_id                             = data.aws_ami.latest_amazon_linux.id
   instance_initiated_shutdown_behavior = "terminate"
   instance_type                        = var.instance_type
+  instance_market_options {
+    market_type = "spot"
+  }
   user_data = base64encode(<<EOF
 #!/bin/bash -xe
 exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1


### PR DESCRIPTION
A Spot Instance is an instance that uses spare EC2 capacity that is available for less than the On-Demand price.

We can use this type because it's safe and even good to recreate instances in our case (new external IP and latest docker image).
