### PR TITLE
[bug] aws terraform state fix

### DIFF
--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -30,7 +30,7 @@ resource "aws_iam_role" "web_iam_role" {
     {
       "Action": "sts:AssumeRole",
       "Principal": {
-        "Service": ["ec2.amazonaws.com", "ssm.amazonaws.com" ]
+        "Service": ["ssm.amazonaws.com", "ec2.amazonaws.com"]
       },
       "Effect": "Allow",
       "Sid": ""


### PR DESCRIPTION
# Description

Small fix to prevent terraform state refreshing warning.

```
aws_autoscaling_group.example: Refreshing state... [id=ir_db1000n]

Note: Objects have changed outside of Terraform

Terraform detected the following changes made outside of Terraform since the last "terraform apply":

  # aws_iam_role.web_iam_role has changed
  ~ resource "aws_iam_role" "web_iam_role" {
      ~ assume_role_policy    = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Principal = {
                          ~ Service = [
                              - "ec2.amazonaws.com",
                                "ssm.amazonaws.com",
                              + "ec2.amazonaws.com",
                            ]
                        }
                        # (3 unchanged elements hidden)
                    },
                ]
                # (1 unchanged element hidden)
            }
        )
        id                    = "ir_db1000n_role"
        name                  = "ir_db1000n_role"
        tags                  = {}
        # (8 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }


Unless you have made equivalent changes to your configuration, or ignored the relevant attributes using ignore_changes, the following plan may include actions to undo or respond to these changes.

No changes. Your infrastructure matches the configuration.

Your configuration already matches the changes detected above. If you'd like to update the Terraform state to match, create and apply a refresh-only plan:
  terraform apply -refresh-only

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```