### PR TITLE
Fix memory leak for the non-closed response body

### DIFF
--- a/src/jobs/http.go
+++ b/src/jobs/http.go
@@ -180,6 +180,10 @@ func sendRequest(client *http.Client, req *http.Request, debug bool) {
 	}
 
 	resp, err := client.Do(req)
+	if resp != nil {
+		resp.Body.Close() // No need for response
+	}
+
 	if err != nil {
 		metrics.IncHTTP(req.Host, req.Method, metrics.StatusFail)
 		if debug {
@@ -189,8 +193,6 @@ func sendRequest(client *http.Client, req *http.Request, debug bool) {
 		return
 	}
 	metrics.IncHTTP(req.Host, req.Method, metrics.StatusSuccess)
-
-	resp.Body.Close() // No need for response
 
 	if debug {
 		if resp.StatusCode >= http.StatusBadRequest {


### PR DESCRIPTION
Addressing the issue: https://github.com/Arriven/db1000n/issues/225
References:
* http://devs.cloudimmunity.com/gotchas-and-common-mistakes-in-go-golang/index.html#close_http_resp_body

Stay safe, take care, and benchmark only appropriate resources (that you own).