### PR TITLE
Add basic auth and tls support for prometheus exporter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,15 @@
+REPOSITORY_BASE_PATH := github.com/Arriven/db1000n
 build:
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="${LDFLAGS}" -o main ./main.go
 
 ifneq ($(ENCRYPTION_KEYS),)
-LDFLAGS += -X 'github.com/Arriven/db1000n/src/utils.EncryptionKeys=$(ENCRYPTION_KEYS)'
+LDFLAGS += -X '$(REPOSITORY_BASE_PATH)/src/utils.EncryptionKeys=$(ENCRYPTION_KEYS)'
 endif
 ifneq ($(DEFAULT_CONFIG_VALUE),)
-LDFLAGS += -X 'github.com/Arriven/db1000n/src/runner/config.DefaultConfig=$(DEFAULT_CONFIG_VALUE)'
+LDFLAGS += -X '$(REPOSITORY_BASE_PATH)/src/runner/config.DefaultConfig=$(DEFAULT_CONFIG_VALUE)'
+endif
+ifneq ($(CA_PATH_VALUE),)
+LDFLAGS += -X '$(REPOSITORY_BASE_PATH)/src/metrics.PushGatewayCA=$(CA_PATH_VALUE)'
 endif
 
 build_encrypted: build
@@ -15,10 +19,21 @@ encrypt_config:
 		echo "Not specified DEFAULT_CONFIG"; \
 	else \
 		file=`tempfile` && \
-		echo "Saved in file: $${file}"; \
 		age --encrypt -p --output $${file} $(DEFAULT_CONFIG) && \
+		echo "Saved in file: $${file}"; \
 		config=`cat $${file} | base64 | tr -d '\n'` && \
 		echo "Save value as env variable: \nexport DEFAULT_CONFIG_VALUE='$${config}'"; \
+	fi
+
+encrypt_ca:
+	@if [ "$(CA_PATH)" = "" ]; then \
+		echo "Not specified CA_PATH"; \
+	else \
+		file=`tempfile` && \
+		age --encrypt -p --output $${file} $(CA_PATH) && \
+		echo "Saved in file: $${file}"; \
+		config=`cat $${file} | base64 | tr -d '\n'` && \
+		echo "Save value as env variable: \nexport CA_PATH_VALUE='$${config}'"; \
 	fi
 
 docker_build:

--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -1,0 +1,65 @@
+# Exporting metrics
+
+Prometheus exporter can be configured with next CLI parameters:
+- `--prometheus_on` - turns on prometheus exporter
+- `--prometheus_gateways=<url>,<url>` - comma separated list of urls to Push Gateway. Example: `https://localhost:9091`.
+  It uses TLS for https:// schema otherwise raw TCP connection
+
+With env variables:
+- `PROMETHEUS_PUSH_PERIOD` - set interval for pushing metrics. Default: `1m`
+- `PROMETHEUS_JOB_NAME` - name for job used in metric pushes
+
+Exporter uses basic authentication with credentials stored in `src/prometheus.BasicAuth` variable encrypted with 
+`src/utils/EncryptionKeys` default key.
+
+Additionally, exporter may be configured with embedded encrypted CA used for TLS connections to push gateways to verify
+self-signed server's certificates
+
+## How to encrypt new credentials
+
+Let's use next credentials for example: `username:password` and our `EncryptionKey: YWtzZGthbHNkCg==`
+```
+echo -ne 'username:password' > /tmp/credentials
+age --encrypt -p --output /tmp/credentials.enc /tmp/credentials
+```
+
+Pass password:
+```
+Enter passphrase (leave empty to autogenerate a secure one): YWtzZGthbHNkCg==
+Confirm passphrase: YWtzZGthbHNkCg==
+```
+
+Encode to base64:
+```
+cat /tmp/credentials.enc | base64 | tr -d '\n'
+YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNjcnlwdCBpYWlSV1VBRWcweEt2NWdTd240a0JBIDE4CmlONnhLcURxWEVWdmFuU1RhSVl0dmplNGpLc0FqLzN5SE5neXdnM0xIMVUKLS0tIE1YdVNBVmk1NG9zNzRpQnh2R3U3MDBpWm5MNUxCb0hNeGxKTERGRDFRamMKJkpimmJGSDmxBX2e38Z38EQZK7aq/W29YMbZKz/omNL0GPvurXZA6GTPmmlD/XZ+EjCkW6bKajIS9y9533tsn6MR8NMtFJoS+z7M9b/yd8YJR6fW069b2A==
+```
+
+Now that base64 value you can use to replace `src/prometheus.BasicAuth` variable.
+
+## How to embed self-signed CA for TLS connections into binary
+
+For example, we have PEM encoded CA certificate at `/home/user/ca.crt` and password `YWtzZGthbHNkCg==`.
+Encrypt and generate value:
+```
+make CA_PATH=/home/user/ca.crt encrypt_ca
+Enter passphrase (leave empty to autogenerate a secure one): YWtzZGthbHNkCg==
+Confirm passphrase: YWtzZGthbHNkCg==
+```
+
+Output:
+```
+Saved in file: /tmp/filer21V74
+Save value as env variable: 
+export CA_PATH_VALUE='YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNjcnlwdCBTQ2ZoclNwTkhvVnpFMVVrSlM3ZHhBIDE4ClB5R2NMOEhxZTlLNUExZk5GUGdsUGdzUUpmeG9QR0J5Q3R5dXJuY2ROa1UKLS0tIGtoc2h6UE8yR01CUWNyWDFtMmdod2Q3Sk9HdEd6RjJCYW9KTzlvcDliRXcKZl2L/j+QAAtASYLWIouxE9TOoDKSW+Sca5tv3LY9UKQ+Fj/8i5y4OmAl5ASkrZfzUYP2H2gXBXy6wd6gS7NRuoULUUgFsK0Oqs9HCXyIg3rIhYwdLEef4O2u6cnhzfsvfDgtJGYSOAcJ3/iCkaHUUNOAKL3tVql9/sFKEzFeU/bAHmplEtKlkTeRkudjvGwUtuND0rWZJP2v8lvP+G7jgtWhftsM8ycnTAp+szy1KaLRV+trNrbs/t81E1Z+37++mktKjxIZawxa+0rsaeLICHVW/Xqgqqcf64ZHXt+BBmiFowk+RptMamgjftZWoyUVE+qKmHS4pAxFo1eXXzx6UZhFsGccyuvbcTcfMpQjbJ+Zo5QrS6SSi2SywjlbrBmXlAMh37ZJKsbAN1E9jgZdU8Lp6Sbks9cMAu91rsRicw6+A14ID1+yILn5VPYsZ9mQu4gZONlIbTdMMP6cYnaU8a+5gcHHqZ0YeW5XWWw7cjsqAjQUx40p5ujH0c10gNQXH/lOV7J1/ZzKDsa3CN2WrIlayYOXsFzNzxSBeVCST36bG46DTDFrO1GbeuJ3wFcWtao1LIwKWfpZJ4oNyu0k4PjqjHyAZ2eQCf9Wk9OL+Mecu16QAzGmDFXsxPu40u7dHABNNEospIeGsgQcp0r2Wy3zEum/ZMdJoq2d5w3+nMKaPcH/0sB+aDzJlSr0ovyXIRZSLiGp16I0xBsIdcv0oPKTxj3xvWrJCHLKDjfcNfxId3n4Wyci8ZNDEXWc4erHnYMBD8pZhBzOQxU8EnUBwJts8xO0Ngv6EU08juMIjoQfTnFkGQOQ2QVEVRRTf17MzlzzRyGnbdTUwz7btlk+DEOMaGFDFOfvKu24FV+vFBFa6xINJYKBa3wgNSaAQEJvNi9gKzjnnW/umjNoPh7zLuzJtHyStkg7sSeNWv8A62NFzxs9eBVfZqT67HoMzVKlwHPp8hjYsvhmRzWixdwTkWgejOeWW2q+/z541DvfJkbT0luwo12PYQhJ6S1MM02aDmdByah+cNGtIy8Zptvm/g5VW4qAk4aYtqP4bkONArWeni4/CURVq4GyfUNOE0kWG/cs0NYGSgECsOfVbDaZchcdvNjH/aIfLb0j7+TuuZrWLvj+2jJ7uesweimuCmtACe02KXHTRvr7EfTneQMGcLG7uUvxP19KCc9DiZgbsicwzVeN1DW0ySDLHK54vZ8EiqS7cpHkPisVSPXQIf/jMvu04x6QPzpRRTx7AZqHE8+oF2aLBy+ep/Gt0KYabN0W3vbPu0rtlYWzlElWppfyZD8/G4rNntH3dfyNA1Igl3fP5ydaxsAxZROC9aDGtLyR8LhgM2f/Hg0Ql1LdYKAQM+pxXsXSg+Hblw6vVDf+qcBSJc0Ue0qJi7ieoj0UQr8LLnBInKNk/ZyNPBpEHDZYmYTX6OMJg+0gRvI8kLXB92y9Wzip8Pk5r+jZXzAbe1DboC13XoyO9ZDP0e/UA+d7DheeVVZCjuSJE0+F18UJLDtIvtdJtjBy3jEhST/IWWBNIFqVmjUI2m5ieegInZqyW9x8s4mMvIOwV48bohk9AUM5yfwz459bTSsIafthL6jjkA+ZpICsEh5AwM2IIdpWfswGs+HW1m45stfC1ahjmY6/D5FS6bERYOeiQV/d2q2Ie715IW2qhXG/fHKlBO3UZ72MSZHttxT5oEfy1PBGLoZf1PUpCjh6kroodHnuE7KnOcwPCemRRLyOlAXUeGfyx4PLuc3yMmVwa6wMm7PRY7a2W0zMROjBn2oxj4pV3ZUzHc2sfRoPNbUdQnep2SEnLNyLvyIo35/nR9D891C4WOT4RzYGj00juJkNyb4K2nObMWQHwcPmgDDCl5Dk91vXlf1dajBDrLzBl61Eo6BlNz9stR5mRcDRDVvflh3iWC4='
+```
+
+Now export variable before building binary:
+```
+export CA_PATH_VALUE='YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNjcnlwdCBTQ2ZoclNwTkhvVnpFMVVrSlM3ZHhBIDE4ClB5R2NMOEhxZTlLNUExZk5GUGdsUGdzUUpmeG9QR0J5Q3R5dXJuY2ROa1UKLS0tIGtoc2h6UE8yR01CUWNyWDFtMmdod2Q3Sk9HdEd6RjJCYW9KTzlvcDliRXcKZl2L/j+QAAtASYLWIouxE9TOoDKSW+Sca5tv3LY9UKQ+Fj/8i5y4OmAl5ASkrZfzUYP2H2gXBXy6wd6gS7NRuoULUUgFsK0Oqs9HCXyIg3rIhYwdLEef4O2u6cnhzfsvfDgtJGYSOAcJ3/iCkaHUUNOAKL3tVql9/sFKEzFeU/bAHmplEtKlkTeRkudjvGwUtuND0rWZJP2v8lvP+G7jgtWhftsM8ycnTAp+szy1KaLRV+trNrbs/t81E1Z+37++mktKjxIZawxa+0rsaeLICHVW/Xqgqqcf64ZHXt+BBmiFowk+RptMamgjftZWoyUVE+qKmHS4pAxFo1eXXzx6UZhFsGccyuvbcTcfMpQjbJ+Zo5QrS6SSi2SywjlbrBmXlAMh37ZJKsbAN1E9jgZdU8Lp6Sbks9cMAu91rsRicw6+A14ID1+yILn5VPYsZ9mQu4gZONlIbTdMMP6cYnaU8a+5gcHHqZ0YeW5XWWw7cjsqAjQUx40p5ujH0c10gNQXH/lOV7J1/ZzKDsa3CN2WrIlayYOXsFzNzxSBeVCST36bG46DTDFrO1GbeuJ3wFcWtao1LIwKWfpZJ4oNyu0k4PjqjHyAZ2eQCf9Wk9OL+Mecu16QAzGmDFXsxPu40u7dHABNNEospIeGsgQcp0r2Wy3zEum/ZMdJoq2d5w3+nMKaPcH/0sB+aDzJlSr0ovyXIRZSLiGp16I0xBsIdcv0oPKTxj3xvWrJCHLKDjfcNfxId3n4Wyci8ZNDEXWc4erHnYMBD8pZhBzOQxU8EnUBwJts8xO0Ngv6EU08juMIjoQfTnFkGQOQ2QVEVRRTf17MzlzzRyGnbdTUwz7btlk+DEOMaGFDFOfvKu24FV+vFBFa6xINJYKBa3wgNSaAQEJvNi9gKzjnnW/umjNoPh7zLuzJtHyStkg7sSeNWv8A62NFzxs9eBVfZqT67HoMzVKlwHPp8hjYsvhmRzWixdwTkWgejOeWW2q+/z541DvfJkbT0luwo12PYQhJ6S1MM02aDmdByah+cNGtIy8Zptvm/g5VW4qAk4aYtqP4bkONArWeni4/CURVq4GyfUNOE0kWG/cs0NYGSgECsOfVbDaZchcdvNjH/aIfLb0j7+TuuZrWLvj+2jJ7uesweimuCmtACe02KXHTRvr7EfTneQMGcLG7uUvxP19KCc9DiZgbsicwzVeN1DW0ySDLHK54vZ8EiqS7cpHkPisVSPXQIf/jMvu04x6QPzpRRTx7AZqHE8+oF2aLBy+ep/Gt0KYabN0W3vbPu0rtlYWzlElWppfyZD8/G4rNntH3dfyNA1Igl3fP5ydaxsAxZROC9aDGtLyR8LhgM2f/Hg0Ql1LdYKAQM+pxXsXSg+Hblw6vVDf+qcBSJc0Ue0qJi7ieoj0UQr8LLnBInKNk/ZyNPBpEHDZYmYTX6OMJg+0gRvI8kLXB92y9Wzip8Pk5r+jZXzAbe1DboC13XoyO9ZDP0e/UA+d7DheeVVZCjuSJE0+F18UJLDtIvtdJtjBy3jEhST/IWWBNIFqVmjUI2m5ieegInZqyW9x8s4mMvIOwV48bohk9AUM5yfwz459bTSsIafthL6jjkA+ZpICsEh5AwM2IIdpWfswGs+HW1m45stfC1ahjmY6/D5FS6bERYOeiQV/d2q2Ie715IW2qhXG/fHKlBO3UZ72MSZHttxT5oEfy1PBGLoZf1PUpCjh6kroodHnuE7KnOcwPCemRRLyOlAXUeGfyx4PLuc3yMmVwa6wMm7PRY7a2W0zMROjBn2oxj4pV3ZUzHc2sfRoPNbUdQnep2SEnLNyLvyIo35/nR9D891C4WOT4RzYGj00juJkNyb4K2nObMWQHwcPmgDDCl5Dk91vXlf1dajBDrLzBl61Eo6BlNz9stR5mRcDRDVvflh3iWC4='
+```
+
+And build new binary with embedding encrypted CA certificate:
+```
+make build_encrypted
+```

--- a/src/metrics/prometheus.go
+++ b/src/metrics/prometheus.go
@@ -23,7 +23,12 @@
 package metrics
 
 import (
+	"bytes"
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"errors"
 	"log"
 	"math/rand"
 	"net/http"
@@ -165,6 +170,54 @@ func ExportPrometheusMetrics(ctx context.Context, gateways string) {
 	}
 }
 
+// BasicAuth client's credentials for push gateway encrypted with utils/crypto.go#EncryptionKeys[0] key
+var BasicAuth = `YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNjcnlwdCBpYWlSV1VBRWcweEt2NWdTd240a0JBIDE4CmlONnhLcURxWEVWdmFuU1RhSVl0dmplNGpLc0FqLzN5SE5neXdnM0xIMVUKLS0tIE1YdVNBVmk1NG9zNzRpQnh2R3U3MDBpWm5MNUxCb0hNeGxKTERGRDFRamMKJkpimmJGSDmxBX2e38Z38EQZK7aq/W29YMbZKz/omNL0GPvurXZA6GTPmmlD/XZ+EjCkW6bKajIS9y9533tsn6MR8NMtFJoS+z7M9b/yd8YJR6fW069b2A==`
+
+// getBasicAuth returns decrypted basic auth credential for push gateway
+func getBasicAuth() (string, string, error) {
+	encryptedData, err := base64.StdEncoding.DecodeString(BasicAuth)
+	if err != nil {
+		return "", "", err
+	}
+	decryptedData, err := utils.Decrypt(encryptedData)
+	if err != nil {
+		return "", "", err
+	}
+	parts := bytes.Split(decryptedData, []byte{':'})
+	if len(parts) != 2 {
+		return "", "", errors.New("invalid basic auth credential format")
+	}
+	return string(parts[0]), string(parts[1]), nil
+}
+
+// PushGatewayCA variable to embed self-signed CA for TLS
+var PushGatewayCA string
+
+// getTLSConfig returns tls.Config with system root CAs and embedded CA if not empty
+func getTLSConfig() (*tls.Config, error) {
+	rootCAs := x509.NewCertPool()
+	var err error
+	if rootCAs, err = x509.SystemCertPool(); err != nil {
+		log.Println("Can't get system cert pool")
+	}
+	if PushGatewayCA != "" {
+		decoded, err := base64.StdEncoding.DecodeString(PushGatewayCA)
+		if err != nil {
+			return nil, err
+		}
+		decrypted, err := utils.Decrypt(decoded)
+		if err != nil {
+			return nil, err
+		}
+		if ok := rootCAs.AppendCertsFromPEM(decrypted); !ok {
+			return nil, errors.New("invalid embedded CA")
+		}
+	}
+	return &tls.Config{
+		RootCAs: rootCAs,
+	}, nil
+}
+
 func pushMetrics(ctx context.Context, gateways []string) {
 	jobName := utils.GetEnvStringDefault("PROMETHEUS_JOB_NAME", "default_push")
 
@@ -175,7 +228,23 @@ func pushMetrics(ctx context.Context, gateways []string) {
 		log.Println("Invalid value for <PROMETHEUS_PUSH_PERIOD> env variable. Read docs: https://pkg.go.dev/time#ParseDuration")
 	}
 	ticker := time.NewTicker(tickerPeriod)
-	pusher := push.New(gateway, jobName).Gatherer(prometheus.DefaultGatherer)
+	tlsConfig, err := getTLSConfig()
+	if err != nil {
+		log.Println("Can't get tls config")
+		return
+	}
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+		},
+	}
+	user, password, err := getBasicAuth()
+	if err != nil {
+		log.Println("Can't fetch basic auth credentials")
+		return
+	}
+	pusher := push.New(gateway, jobName).Gatherer(prometheus.DefaultGatherer).Client(httpClient).BasicAuth(user, password)
+
 	for {
 		select {
 		case <-ctx.Done():

--- a/src/runner/config/config.go
+++ b/src/runner/config/config.go
@@ -90,7 +90,7 @@ func Update(paths []string, current, backup []byte, format string) (*Config, []b
 
 	log.Println("New config received, applying")
 	if utils.IsEncrypted(newRawConfig) {
-		decryptedConfig, err := utils.DecryptConfig(newRawConfig)
+		decryptedConfig, err := utils.Decrypt(newRawConfig)
 		if err != nil {
 			log.Println("Can't decrypt config")
 			return nil, nil

--- a/src/utils/crypto.go
+++ b/src/utils/crypto.go
@@ -40,8 +40,8 @@ func IsEncrypted(cfg []byte) bool {
 	return bytes.Index(cfg, []byte(`age-encryption`)) != -1
 }
 
-// DecryptConfig decrypts config using EncryptionKeys
-func DecryptConfig(cfg []byte) ([]byte, error) {
+// Decrypt decrypts config using EncryptionKeys
+func Decrypt(cfg []byte) ([]byte, error) {
 	keys, err := GetEncryptionKeys()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Description
* TLS support for prometheus push exporter
* embed basic auth credentials and use authentication for prometheus push exporter
* optionally use embedded CA used to verify TLS connection with push gateways
* update Makefile with target to encrypt CA and embed to binary
* document prometheus exporter's configuration (look docs/prometheus.md)
* rename utils.DecryptConfig -> utils.Decrypt. Because it is used for all decryption
  operations, not only for configuration files

## Type of change

- [+] New feature (non-breaking change which adds functionality)
- [+] Documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Up push gateway configured with TLS certificates and basic auth. Use [Dockerfile](https://github.com/prometheus/pushgateway/blob/master/Dockerfile) and extend with copying your TLS certificates for gateway, build own image. For example `pushgateway`
- Write configuration file for gateway. Example:
```
  GNU nano 4.8                                                                                push/a.conf                                                                                Modified  
tls_server_config:
  cert_file: /path/server.crt       
  key_file: /path/server.key 

basic_auth_users:
  pushgateway: "<password>"
```
- Run with next command: `docker run  -v `pwd/prom.conf`:/prom.conf -d -p 9091:9091 pushgateway --web.config.file=/prom.conf`
- Run app: `./main --prometheus_on --prometheus_gateways=http://localhost:9091`