### PR TITLE
Fix random ip to not produce invalid IPs

### DIFF
--- a/src/packetgen/utils.go
+++ b/src/packetgen/utils.go
@@ -39,8 +39,8 @@ func RandomPayload(length int) []byte {
 }
 
 func RandomIP() string {
-	return fmt.Sprintf("%d.%d.%d.%d", rand.Intn(256), rand.Intn(256),
-		rand.Intn(256), rand.Intn(256))
+	return fmt.Sprintf("%d.%d.%d.%d", rand.Intn(255)+1, rand.Intn(255)+1,
+		rand.Intn(255)+1, rand.Intn(255)+1)
 }
 
 func RandomPort() int {


### PR DESCRIPTION
# Description

It took me couple days to realize that most of the time when packetgen is bitching about and argument in sendmsg it doesn't like the ip containing leading 0. Tweaked random IP generation function to stop producing those value

Fixes #249 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `sudo go run main.go -r 5s`

## Test Configuration

* Release version: latest
* Platform: linux-amd64
