### PR TITLE
remove redundant resolve host from packetgen.SendPacket

### DIFF
--- a/src/packetgen/packetgen.go
+++ b/src/packetgen/packetgen.go
@@ -56,10 +56,6 @@ func SendPacket(c PacketConfig, destinationHost string, destinationPort int) (in
 		tcpPacket  *layers.TCP
 		err        error
 	)
-	destinationHost, err = ResolveHost(destinationHost)
-	if err != nil {
-		return 0, err
-	}
 	protocolLabelValue := "tcp"
 	ipPacket := buildIpPacket(c.IP)
 	hostPort := destinationHost + ":" + strconv.FormatInt(int64(destinationPort), 10)


### PR DESCRIPTION
# Description

With all the latest changes ResolveHost was there for purely cosmetic reasons. Thanks @jdoe7865623 for noticing!

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Test Configuration

* Release version:
* Platform:

## Logs

```text
logs
```

## Screenshots

- [ ] No screenshot
