### PR TITLE
force resolve host to use ipv4

### DIFF
--- a/src/packetgen/utils.go
+++ b/src/packetgen/utils.go
@@ -90,15 +90,16 @@ func LocalIP() string {
 
 // ResolveHost function gets a string and returns the ip address
 func ResolveHost(host string) (string, error) {
-	addrs, err := net.LookupHost(host)
+	addrs, err := net.LookupIP(host)
 	if err != nil {
 		return "", err
 	}
 
-	// I assume net.LookupHost already handles that but just to be sure
-	if len(addrs) == 0 {
-		return "", fmt.Errorf("no addrs found for host %v", host)
+	for _, addr := range addrs {
+		if addr.To4() != nil {
+			return addr.String(), nil
+		}
 	}
 
-	return addrs[0], nil
+	return "", fmt.Errorf("no addrs found for host %v", host)
 }

--- a/testconfig.json
+++ b/testconfig.json
@@ -60,7 +60,7 @@
     {
       "type": "packetgen",
       "args": {
-        "host": "{{ resolve_host \"google.com\" }}",
+        "host": "{{ resolve_host \"localhost\" }}",
         "port": "{{ random_port }}",
         "packet": {
           "payload": "test:blah",
@@ -70,7 +70,7 @@
           },
           "ip": {
             "src_ip": "{{ local_ip }}",
-            "dst_ip": "{{ resolve_host \"google.com\" }}"
+            "dst_ip": "{{ resolve_host \"localhost\" }}"
           },
           "tcp": {
             "src_port": "{{ random_port }}",


### PR DESCRIPTION
# Description

force usage of ipv4 in `packetgen.ResolveHost`

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Test Configuration

- Release version:
- Platform:

## Logs

```text
logs
```

## Screenshots

- [ ] No screenshot
