### PR TITLE
Added an ability to specify app flags in azure terraform

### DIFF
--- a/terraform/azure/README.md
+++ b/terraform/azure/README.md
@@ -14,6 +14,7 @@ The composition creates container instances in 6 different regions for a broader
 Create a new `terraform.tfvars` file in the folder, if you want to change the default configuration of the farm:
 
 - `bomblet_count=10` - can be used for custom number of containers per region
+- `attack_commands=["/usr/src/app/main","-c=https://link_to_your_config_file"]`
 
 `terrafrom init` - to restore all dependencies.
 

--- a/terraform/azure/bomblet/main.tf
+++ b/terraform/azure/bomblet/main.tf
@@ -14,5 +14,6 @@ resource "azurerm_container_group" "main" {
     memory = var.attack_memory
 
     environment_variables = var.attack_environment_variables
+    commands = var.attack_commands
   }
 }

--- a/terraform/azure/bomblet/variables.tf
+++ b/terraform/azure/bomblet/variables.tf
@@ -21,3 +21,7 @@ variable "attack_memory" {
 variable "attack_environment_variables" { 
   default = {}
 }
+
+variable "attack_commands" {
+  default = ["/usr/src/app/main","-c=https://raw.githubusercontent.com/db1000n-coordinators/LoadTestConfig/main/config.json"]
+}

--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -14,6 +14,7 @@ module "bomblet" {
   region              = "northeurope"
   prefix              = var.prefix
   resource_group_name = azurerm_resource_group.main.name
+  attack_commands     = var.attack_commands
 }
 
 module "bomblet_we" {
@@ -23,6 +24,7 @@ module "bomblet_we" {
   region              = "westeurope"
   prefix              = var.prefix
   resource_group_name = azurerm_resource_group.main.name
+  attack_commands     = var.attack_commands
 }
 
 module "bomblet_cc" {
@@ -32,6 +34,7 @@ module "bomblet_cc" {
   region              = "canadacentral"
   prefix              = var.prefix
   resource_group_name = azurerm_resource_group.main.name
+  attack_commands     = var.attack_commands
 }
 
 module "bomblet_uae" {
@@ -41,6 +44,7 @@ module "bomblet_uae" {
   region              = "uaenorth"
   prefix              = var.prefix
   resource_group_name = azurerm_resource_group.main.name
+  attack_commands     = var.attack_commands
 }
 
 module "bomblet_cu" {
@@ -50,6 +54,7 @@ module "bomblet_cu" {
   region              = "centralus"
   prefix              = var.prefix
   resource_group_name = azurerm_resource_group.main.name
+  attack_commands     = var.attack_commands
 }
 
 module "bomblet_ea" {
@@ -59,4 +64,5 @@ module "bomblet_ea" {
   region              = "eastasia"
   prefix              = var.prefix
   resource_group_name = azurerm_resource_group.main.name
+  attack_commands     = var.attack_commands
 }

--- a/terraform/azure/variables.tf
+++ b/terraform/azure/variables.tf
@@ -8,3 +8,8 @@ variable "prefix" {
   default     = "attack"
   description = "The default prefix for resources."
 }
+
+variable "attack_commands" {
+  default     = ["/usr/src/app/main","-c=https://raw.githubusercontent.com/db1000n-coordinators/LoadTestConfig/main/config.json"]
+  description = "The command to execute an attack with support of specifying additional flags."
+}


### PR DESCRIPTION
# Description
This PR adds an ability to explicitly specify db1000n flags in Azure terraform scripts. It might be very useful in case if custom config is required to be used.

## Usage
Specify `attack_commands` variable in `terraform.tfvars`
``
attack_commands = ["/usr/src/app/main","-c=https://link_to_config"]
`