### PR TITLE
Increase HTTP timeout for fetching config to 20 seconds

### DIFF
--- a/src/runner/config/config.go
+++ b/src/runner/config/config.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"time"
 
 	"github.com/Arriven/db1000n/src/utils"
 
@@ -52,7 +53,10 @@ func fetchSingle(path string) ([]byte, error) {
 		return res, nil
 	}
 
-	resp, err := http.Get(configURL.String())
+	client := http.Client{
+		Timeout: 20 * time.Second,
+	}
+	resp, err := client.Get(configURL.String())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Description

I found config updating process throws less errors when timeout is increased. Which makes sense since `db1000n` saturates your channel if you're using VPN.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)