### PR TITLE
Add willfarrell/autoheal to docker-compose.yaml to restart OpenVPN containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,16 @@
-version: "3"
+version: "3.9"
 
 services:
+
+  # creates privileged container
+  autoheal:
+    container_name: autoheal
+    image: willfarrell/autoheal:1.2.0
+    restart: always
+    privileged: true
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:Z
+
   # creates OpenVPN Docker container to first provider that randomly picks .conf file
   ovpn_01:
     image: ghcr.io/wfg/openvpn-client:2.1.0
@@ -19,6 +29,11 @@ services:
       HTTP_PROXY: "off"
       VPN_AUTH_SECRET: provider01_secret
       VPN_CONFIG_PATTERN: provider01*.conf # this will match provider01_country01.conf, provider01_country02.conf etc
+    healthcheck:
+      test: [ "CMD", "nslookup", "google.com" ]
+      timeout: 10s
+      interval: 30s
+      retries: 3
     secrets:
       - provider01_secret
 
@@ -35,11 +50,18 @@ services:
       - ./openvpn/:/data/vpn:z
     sysctls:
       - net.ipv6.conf.all.disable_ipv6=1
+    labels:
+        autoheal: "true"
     environment:
       KILL_SWITCH: "on"
       HTTP_PROXY: "off"
       VPN_AUTH_SECRET: provider01_secret
       VPN_CONFIG_FILE: provider01.endpoint02.conf # will use only this .conf file
+    healthcheck:
+      test: [ "CMD", "nslookup", "google.com" ]
+      timeout: 10s
+      interval: 30s
+      retries: 3
     secrets:
       - provider01_secret
 
@@ -56,6 +78,8 @@ services:
       - ./openvpn/:/data/vpn:z
     sysctls:
       - net.ipv6.conf.all.disable_ipv6=1
+    labels:
+        autoheal: "true"
     environment:
       KILL_SWITCH: "on"
       HTTP_PROXY: "off"


### PR DESCRIPTION
# Description

This runs a command of your choice (`nslookup google.com`) every X seconds to verify that OpenVPN container still has an active VPN connection. If it doesn't, containers with `autoheal: true` label will be auto-restarted by [autoheal](https://github.com/willfarrell/docker-autoheal). While container is restarting, `db1000n` won't be able to access network so there should be no traffic leakage.

I've reviewed `autoheal` source code and it looks pretty reasonable.

Unfortunately accessing Docker socket requires running this container with privileged access.

```
timeout: 10s
interval: 30s
retries: 3
```

These values were selected by running a couple of experiments and they seem decent defaults but they might have to be adjusted to your particular situation.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested by running `docker-compose up`
