### PR TITLE
Fix goroutine leaks if job fails

### DIFF
--- a/src/dnsblast/dns-blast.go
+++ b/src/dnsblast/dns-blast.go
@@ -41,7 +41,7 @@ type Config struct {
 type DNSBlaster struct{}
 
 // Start starts the job based on provided configuration
-func Start(ctx context.Context, config *Config) error {
+func Start(ctx context.Context, wg *sync.WaitGroup, config *Config) error {
 	defer utils.PanicHandler()
 
 	log.Printf("[DNS BLAST] igniting the blaster, parameters to start: "+
@@ -68,7 +68,13 @@ func Start(ctx context.Context, config *Config) error {
 	}
 
 	for _, nameserver := range nameservers {
+		if wg != nil {
+			wg.Add(1)
+		}
 		go func(nameserver string, parameters *StressTestParameters) {
+			if wg != nil {
+				defer wg.Done()
+			}
 			defer utils.PanicHandler()
 
 			if err := blaster.ExecuteStressTest(ctx, nameserver, parameters); err != nil {

--- a/src/dnsblast/dns-blast_test.go
+++ b/src/dnsblast/dns-blast_test.go
@@ -88,7 +88,7 @@ func TestBlast(t *testing.T) {
 			blastContext, cancel := context.WithTimeout(context.Background(), testcase.Duration)
 			defer cancel()
 
-			err := Start(blastContext, config)
+			err := Start(blastContext, nil, config)
 			if err != nil {
 				tt.Errorf("failed to start the blaster: %s", err)
 				return

--- a/src/jobs/base.go
+++ b/src/jobs/base.go
@@ -3,6 +3,7 @@ package jobs
 
 import (
 	"context"
+	"time"
 )
 
 // Args comment for linter
@@ -52,14 +53,13 @@ func (c *BasicJobConfig) Next(ctx context.Context) bool {
 	select {
 	case <-ctx.Done():
 		return false
-	default:
+	case <-time.After(time.Duration(c.IntervalMs) * time.Millisecond):
+		if c.Count <= 0 {
+			return true
+		}
+
+		c.iter++
+
+		return c.iter <= c.Count
 	}
-
-	if c.Count <= 0 {
-		return true
-	}
-
-	c.iter++
-
-	return c.iter <= c.Count
 }

--- a/src/jobs/dnsblast.go
+++ b/src/jobs/dnsblast.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/Arriven/db1000n/src/dnsblast"
@@ -75,14 +76,18 @@ func dnsBlastJob(ctx context.Context, globalConfig GlobalConfig, args Args, debu
 		jobConfig.IntervalMs = defaultIntervalInMS
 	}
 
+	var wg sync.WaitGroup
+
 	//
 	// Blast the Job!
 	//
-	return dnsblast.Start(ctx, &dnsblast.Config{
+	err = dnsblast.Start(ctx, &wg, &dnsblast.Config{
 		RootDomain:      jobConfig.RootDomain,
 		Protocol:        jobConfig.Protocol,
 		SeedDomains:     jobConfig.SeedDomains,
 		ParallelQueries: jobConfig.ParallelQueries,
 		Delay:           time.Duration(jobConfig.IntervalMs) * time.Millisecond,
 	})
+	wg.Wait()
+	return err
 }

--- a/src/jobs/dnsblast.go
+++ b/src/jobs/dnsblast.go
@@ -26,6 +26,8 @@ type dnsBlastConfig struct {
 }
 
 func dnsBlastJob(ctx context.Context, globalConfig GlobalConfig, args Args, debug bool) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	defer utils.PanicHandler()
 
 	var jobConfig dnsBlastConfig

--- a/src/jobs/http.go
+++ b/src/jobs/http.go
@@ -82,8 +82,6 @@ func fastHTTPJob(ctx context.Context, globalConfig GlobalConfig, args Args, debu
 		} else {
 			processedTrafficMonitor.Add(dataSize)
 		}
-
-		time.Sleep(time.Duration(jobConfig.IntervalMs) * time.Millisecond)
 	}
 
 	return nil

--- a/src/jobs/packetgen.go
+++ b/src/jobs/packetgen.go
@@ -16,6 +16,8 @@ import (
 )
 
 func packetgenJob(ctx context.Context, globalConfig GlobalConfig, args Args, debug bool) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	defer utils.PanicHandler()
 
 	type packetgenJobConfig struct {

--- a/src/jobs/rawnet.go
+++ b/src/jobs/rawnet.go
@@ -26,6 +26,8 @@ type rawNetJobConfig struct {
 }
 
 func tcpJob(ctx context.Context, globalConfig GlobalConfig, args Args, debug bool) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	defer utils.PanicHandler()
 
 	type tcpJobConfig struct {
@@ -91,6 +93,8 @@ func tcpJob(ctx context.Context, globalConfig GlobalConfig, args Args, debug boo
 }
 
 func udpJob(ctx context.Context, globalConfig GlobalConfig, args Args, debug bool) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	defer utils.PanicHandler()
 
 	type udpJobConfig struct {

--- a/src/jobs/rawnet.go
+++ b/src/jobs/rawnet.go
@@ -87,8 +87,6 @@ func tcpJob(ctx context.Context, globalConfig GlobalConfig, args Args, debug boo
 		}
 	}
 
-	time.Sleep(time.Duration(jobConfig.IntervalMs) * time.Millisecond)
-
 	return nil
 }
 
@@ -149,8 +147,6 @@ func udpJob(ctx context.Context, globalConfig GlobalConfig, args Args, debug boo
 				log.Printf("%s started at %d", jobConfig.Address, time.Now().Unix())
 			}
 		}
-
-		time.Sleep(time.Duration(jobConfig.IntervalMs) * time.Millisecond)
 	}
 
 	return nil

--- a/src/jobs/slowloris.go
+++ b/src/jobs/slowloris.go
@@ -12,6 +12,8 @@ import (
 )
 
 func slowLorisJob(ctx context.Context, globalConfig GlobalConfig, args Args, debug bool) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	defer utils.PanicHandler()
 
 	var jobConfig *slowloris.Config


### PR DESCRIPTION
# Description

Use local function context in order to prevent metric writers being running after the job has crashed

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
