### PR TITLE
Remove warning about slowloris being unfinished

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -81,8 +81,6 @@ Warning: `packetgen` requires root privileges to run
 - `tcp.urgent` - `[number]`
 - `tcp.flags` - `[object]` flags for tcp (every flag has its respective name)
 
-Warning: `slow-loris` from testconfig.json is not yet finished and may overload the app due to not handling config refreshes
-
 Almost every leaf `[string]` or `[object]` parameter can be templated with go template syntax. I've also added couple helper functions (list will be growing):
 
 - `random_uuid`


### PR DESCRIPTION
Slowloris has been fixed couple days ago to support preliminary stop. Forgot to update configuration reference (TODO: update the configuration doc with all new jobs parameters)

- [ ] Documentation update
