### PR TITLE
Use ENTRYPOINT instead of CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,4 @@ RUN apk add --update curl && rm  -rf /tmp/* /var/cache/apk/*
 WORKDIR /usr/src/app
 COPY --from=builder /build/db1000n .
 
-CMD ["./db1000n"]
+ENTRYPOINT ["./db1000n"]


### PR DESCRIPTION
# Description

To be able to pass only args, instead of both command and args:

```
    spec:
      containers:
        - name: db1000n
          image: ghcr.io/arriven/db1000n:latest
          args: ["-enable-self-update"]
```

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)