### PR TITLE
Added healthcheck and autoheal labels

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,13 +29,15 @@ services:
       HTTP_PROXY: "off"
       VPN_AUTH_SECRET: provider01_secret
       VPN_CONFIG_PATTERN: provider01*.conf # this will match provider01_country01.conf, provider01_country02.conf etc
+    secrets:
+      - provider01_secret
+    labels:
+        autoheal: "true"
     healthcheck:
       test: [ "CMD", "nslookup", "google.com" ]
       timeout: 10s
       interval: 30s
       retries: 3
-    secrets:
-      - provider01_secret
 
   # creates OpenVPN Docker container to first provider with specific .conf file
   ovpn_02:
@@ -50,20 +52,20 @@ services:
       - ./openvpn/:/data/vpn:z
     sysctls:
       - net.ipv6.conf.all.disable_ipv6=1
-    labels:
-        autoheal: "true"
     environment:
       KILL_SWITCH: "on"
       HTTP_PROXY: "off"
       VPN_AUTH_SECRET: provider01_secret
       VPN_CONFIG_FILE: provider01.endpoint02.conf # will use only this .conf file
+    secrets:
+      - provider01_secret
+    labels:
+        autoheal: "true"
     healthcheck:
       test: [ "CMD", "nslookup", "google.com" ]
       timeout: 10s
       interval: 30s
       retries: 3
-    secrets:
-      - provider01_secret
 
   # creates OpenVPN Docker container to second provider with specific .conf file
   ovpn_03:
@@ -78,8 +80,6 @@ services:
       - ./openvpn/:/data/vpn:z
     sysctls:
       - net.ipv6.conf.all.disable_ipv6=1
-    labels:
-        autoheal: "true"
     environment:
       KILL_SWITCH: "on"
       HTTP_PROXY: "off"
@@ -87,6 +87,13 @@ services:
       VPN_CONFIG_FILE: provider02.endpoint01.conf # will use only this .conf file
     secrets:
       - provider02_secret
+    labels:
+        autoheal: "true"
+    healthcheck:
+      test: [ "CMD", "nslookup", "google.com" ]
+      timeout: 10s
+      interval: 30s
+      retries: 3
 
   # this Docker container will use VPN 01
   db1000n_01:
@@ -95,6 +102,13 @@ services:
     depends_on:
       - ovpn_01
     network_mode: "service:ovpn_01"
+    labels:
+        autoheal: "true"
+    healthcheck:
+      test: [ "CMD", "nslookup", "google.com" ]
+      timeout: 10s
+      interval: 30s
+      retries: 3
 
   # this Docker container will use VPN 02
   db1000n_02:
@@ -103,6 +117,13 @@ services:
     depends_on:
       - ovpn_02
     network_mode: "service:ovpn_02"
+    labels:
+        autoheal: "true"
+    healthcheck:
+      test: [ "CMD", "nslookup", "google.com" ]
+      timeout: 10s
+      interval: 30s
+      retries: 3
 
   # this Docker container will use VPN 03
   db1000n_03:
@@ -111,6 +132,13 @@ services:
     depends_on:
       - ovpn_03
     network_mode: "service:ovpn_03"
+    labels:
+        autoheal: "true"
+    healthcheck:
+      test: [ "CMD", "nslookup", "google.com" ]
+      timeout: 10s
+      interval: 30s
+      retries: 3
 
 secrets:
   provider01_secret:


### PR DESCRIPTION
Added healthcheck and autoheal labels to every container

# Description

Think for `willfarrell/autoheal` container to work properly the `healthcheck` and `label` should be on every container. Currently If `ovpn_XX` container stops working and is restarted by autoheal, the `db1000n_XX` that depends on it will not have a functioning network and needs are restart also. (At least in my testing)