### PR TITLE
Add --strict-country-check and --country-list command line parameters

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,6 +104,8 @@ services:
     network_mode: "service:ovpn_01"
     labels:
         autoheal: "true"
+    # set single country to check IP against and exit container if IP matches country OR IP cannot be determined
+    entrypoint: "./db1000n --strict-country-check --country-list='Country'"
     healthcheck:
       test: [ "CMD", "nslookup", "google.com", "8.8.8.8" ]
       timeout: 10s
@@ -119,6 +121,8 @@ services:
     network_mode: "service:ovpn_02"
     labels:
         autoheal: "true"
+    # set multiple countries to check IP against and exit container if IP matches country OR IP cannot be determined
+    entrypoint: "./db1000n --strict-country-check --country-list='Country, Another Country'"
     healthcheck:
       test: [ "CMD", "nslookup", "google.com", "8.8.8.8" ]
       timeout: 10s
@@ -134,6 +138,8 @@ services:
     network_mode: "service:ovpn_03"
     labels:
         autoheal: "true"
+    # set single country to check IP against but do not exit container if IP matches country
+    entrypoint: "./db1000n --strict-country-check --country-list='Country'"
     healthcheck:
       test: [ "CMD", "nslookup", "google.com", "8.8.8.8" ]
       timeout: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,7 +105,9 @@ services:
     labels:
         autoheal: "true"
     # set single country to check IP against and exit container if IP matches country OR IP cannot be determined
-    entrypoint: "./db1000n --strict-country-check --country-list='Country'"
+    environment:
+      STRICT_COUNTRY_CHECK: "true"
+      COUNTRY_LIST: "Country"
     healthcheck:
       test: [ "CMD", "nslookup", "google.com", "8.8.8.8" ]
       timeout: 10s
@@ -122,7 +124,9 @@ services:
     labels:
         autoheal: "true"
     # set multiple countries to check IP against and exit container if IP matches country OR IP cannot be determined
-    entrypoint: "./db1000n --strict-country-check --country-list='Country, Another Country'"
+    environment:
+      STRICT_COUNTRY_CHECK: "true"
+      COUNTRY_LIST: "Country, Another Country"
     healthcheck:
       test: [ "CMD", "nslookup", "google.com", "8.8.8.8" ]
       timeout: 10s
@@ -139,7 +143,9 @@ services:
     labels:
         autoheal: "true"
     # set single country to check IP against but do not exit container if IP matches country
-    entrypoint: "./db1000n --strict-country-check --country-list='Country'"
+    environment:
+      STRICT_COUNTRY_CHECK: "false"
+      COUNTRY_LIST: "Country"
     healthcheck:
       test: [ "CMD", "nslookup", "google.com", "8.8.8.8" ]
       timeout: 10s

--- a/main.go
+++ b/main.go
@@ -95,11 +95,9 @@ func main() {
 		templates.SetProxiesURL(*proxiesURL)
 	}
 
-	countries := strings.Split(*countryList, ",")
-	if !utils.CheckCountry(countries) && *strictCountryCheck {
-		if !utils.CheckCountry(countries) {
-			log.Fatal("Strict country check mode is enabled, exiting")
-
+	if *countryList != "" {
+		countries := strings.Split(*countryList, ",")
+		if !utils.CheckCountry(countries, *strictCountryCheck) {
 			return
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ import (
 	pprofhttp "net/http/pprof"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -68,6 +69,8 @@ func main() {
 	doRestartOnUpdate := flag.Bool("restart-on-update", utils.GetEnvBoolDefault("RESTART_ON_UPDATE", true), "Allows application to restart upon successful update (ignored if auto-update is disabled)")
 	skipUpdateCheckOnStart := flag.Bool("skip-update-check-on-start", utils.GetEnvBoolDefault("SKIP_UPDATE_CHECK_ON_START", false), "Allows to skip the update check at the startup (usually set automatically by the previous version)")
 	autoUpdateCheckFrequency := flag.Duration("self-update-check-frequency", utils.GetEnvDurationDefault("SELF_UPDATE_CHECK_FREQUENCY", DefaultUpdateCheckFrequency), "How often to run auto-update checks")
+	strictCountryCheck := flag.BoolVar("strict-country-check", false, "enable strict country check; will also exit if IP can't be determined")
+	countryList := flag.StringVar("country-list", "Ukraine", "comma-separated list of countries")
 
 	flag.Parse()
 
@@ -90,6 +93,13 @@ func main() {
 
 	if *proxiesURL != "" {
 		templates.SetProxiesURL(*proxiesURL)
+	}
+
+	countries := strings.Split(countryList, ",")
+	if !utils.CheckCountry(countries) {
+		if strictCountryCheck {
+			return
+		}
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/src/utils/countrychecker.go
+++ b/src/utils/countrychecker.go
@@ -6,25 +6,12 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
-	"os/exec"
-	"runtime"
 	"strings"
 	"time"
 )
 
-func openBrowser(url string) {
-	switch runtime.GOOS {
-	case "windows":
-		_ = exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
-	case "darwin":
-		_ = exec.Command("open", url).Start()
-	}
-
-	log.Printf("Please open %s", url)
-}
-
 // CheckCountry allows to check which country the app is running from
-func CheckCountry(countriesToAvoid []string) bool {
+func CheckCountry(countriesToAvoid []string, strictCountryCheck bool) bool {
 	type IPInfo struct {
 		Country string `json:"country"`
 		IP      string `json:"ip"`
@@ -83,15 +70,27 @@ func CheckCountry(countriesToAvoid []string) bool {
 	}
 
 	if ipInfo.Country == "" {
-		return false
+		if strictCountryCheck {
+			log.Println("Strict country check mode is enabled, exiting")
+
+			return false
+		}
+
+		return true
 	}
 
 	for _, country := range countriesToAvoid {
 		if ipInfo.Country == strings.TrimSpace(country) {
 			log.Printf("Current country: %s. You might need to enable VPN.", ipInfo.Country)
-			openBrowser("https://arriven.github.io/db1000n/vpn/")
+			OpenBrowser("https://arriven.github.io/db1000n/vpn/")
 
-			return false
+			if strictCountryCheck {
+				log.Println("Strict country check mode is enabled, exiting")
+
+				return false
+			}
+
+			return true
 		}
 	}
 

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -4,6 +4,8 @@ package utils
 import (
 	"log"
 	"os"
+	"os/exec"
+	"runtime"
 	"strconv"
 	"time"
 
@@ -88,4 +90,15 @@ func Decode(input interface{}, output interface{}) error {
 	}
 
 	return decoder.Decode(input)
+}
+
+func OpenBrowser(url string) {
+	switch runtime.GOOS {
+	case "windows":
+		_ = exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
+	case "darwin":
+		_ = exec.Command("open", url).Start()
+	}
+
+	log.Printf("Please open %s", url)
 }


### PR DESCRIPTION
# Description

I'm still trying to figure out how to make Docker VPN setup be more stable, hopefully this is step in right direction.

IP/Country check will be performed before starting any jobs. This is slight departure from current code but it shouldn't be a breaking change as options are turned off by default.

Setting `--country-list` parameter allows to specify comma-separated list of countries to check IP against

Setting `--strict-country-check` parameter will result in app exiting if

- IP matches one of the countries in the list above OR
- IP cannot be determined

Since `db1000n` container starts right after VPN container starts, there's little no guarantee that VPN tunnel is actually established. This often results in app not being able to download configuration and default to built-in configuration. Typically after a minute or two it will manage to download conf file.

If we wait until we're actually able to determine IP from the app, this fixes this problem.

Additionally it should fix an issue when VPN tunnel is established, but no Internet is available, container will simply exit if using `--strict-country-check` option and will be auto-healed.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Logs

```text
07:52:17 Initialization Sequence Completed
07:52:23.358383 countrychecker.go:40: Can't check users country. Please manually check that VPN is enabled or that you have non Ukrainian IP address.
07:52:24.359966 countrychecker.go:37: Checking IP address, attempt #2
07:52:26.990324 countrychecker.go:70: Current country: ******* (193.*.***.***)
07:52:27.005959 config.go:36: Loading config from "jobs.json"
07:52:27.005992 config.go:97: New config received, applying
```