### PR TITLE
Refactor how configs are fetched

### DIFF
--- a/src/runner/config/config.go
+++ b/src/runner/config/config.go
@@ -4,7 +4,6 @@ package config
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -24,10 +23,32 @@ type Config struct {
 	Jobs []jobs.Config
 }
 
+type RawConfig struct {
+	body         []byte
+	lastModified string
+	etag         string
+}
+
+type Fetcher struct {
+	backupConfig    []byte
+	lastKnownConfig RawConfig
+}
+
+func NewFetcher(backupConfig []byte) *Fetcher {
+	return &Fetcher{
+		backupConfig: backupConfig,
+		lastKnownConfig: RawConfig{
+			body:         nil,
+			lastModified: "",
+			etag:         "",
+		},
+	}
+}
+
 // fetch tries to read a config from the list of mirrors until it succeeds
-func fetch(paths []string) ([]byte, error) {
+func (f *Fetcher) fetch(paths []string) *RawConfig {
 	for i := range paths {
-		res, err := fetchSingle(paths[i])
+		config, err := f.fetchSingle(paths[i])
 		if err != nil {
 			log.Printf("Failed to fetch config from %q: %v", paths[i], err)
 
@@ -36,14 +57,22 @@ func fetch(paths []string) ([]byte, error) {
 
 		log.Printf("Loading config from %q", paths[i])
 
-		return res, nil
+		return config
 	}
 
-	return nil, errors.New("config fetch failed")
+	if f.lastKnownConfig.body != nil {
+		log.Println("Could not load new config, proceeding with the last known good one")
+
+		return &f.lastKnownConfig
+	}
+
+	log.Println("Could not load new config, proceeding with the backup one")
+
+	return &RawConfig{body: f.backupConfig, lastModified: "", etag: ""}
 }
 
 // fetchSingle reads a config from a single source
-func fetchSingle(path string) ([]byte, error) {
+func (f *Fetcher) fetchSingle(path string) (*RawConfig, error) {
 	configURL, err := url.ParseRequestURI(path)
 	if err != nil {
 		res, err := os.ReadFile(path)
@@ -51,7 +80,7 @@ func fetchSingle(path string) ([]byte, error) {
 			return nil, err
 		}
 
-		return res, nil
+		return &RawConfig{body: res, lastModified: "", etag: ""}, nil
 	}
 
 	const requestTimeout = 20 * time.Second
@@ -59,10 +88,19 @@ func fetchSingle(path string) ([]byte, error) {
 	client := http.Client{
 		Timeout: requestTimeout,
 	}
+	req, _ := http.NewRequest(http.MethodGet, configURL.String(), nil)
+	req.Header.Add("If-None-Match", f.lastKnownConfig.etag)
+	req.Header.Add("If-Modified-Since", f.lastKnownConfig.lastModified)
 
-	resp, err := client.Get(configURL.String())
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
+	}
+
+	if resp.StatusCode == http.StatusNotModified {
+		log.Println("Received HTTP 304 Not Modified")
+
+		return &f.lastKnownConfig, nil
 	}
 
 	defer resp.Body.Close()
@@ -71,68 +109,62 @@ func fetchSingle(path string) ([]byte, error) {
 		return nil, fmt.Errorf("error fetching config, code %d", resp.StatusCode)
 	}
 
+	etag := resp.Header.Get("etag")
+	lastModified := resp.Header.Get("last-modified")
+
 	res, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
 
-	return res, nil
+	return &RawConfig{body: res, etag: etag, lastModified: lastModified}, nil
 }
 
 // Update the job config from a list of paths or the built-in backup. Returns nil, nil in case of no changes.
-func Update(paths []string, current, backup []byte, format string) (*Config, []byte) {
-	newRawConfig, err := fetch(paths)
-	if err != nil {
-		if current != nil {
-			log.Println("Could not load new config, proceeding with the last known good one")
+func (f *Fetcher) Update(paths []string, format string) *Config {
+	newConfig := f.fetch(paths)
 
-			newRawConfig = current
-		} else {
-			log.Println("Could not load new config, proceeding with the backup one")
-
-			newRawConfig = backup
-		}
-	}
-
-	if bytes.Equal(current, newRawConfig) { // Only restart jobs if the new config differs from the current one
-		log.Println("The config has not changed. Keep calm and carry on!")
-
-		return nil, nil
-	}
-
-	log.Println("New config received, applying")
-
-	if utils.IsEncrypted(newRawConfig) {
-		decryptedConfig, err := utils.Decrypt(newRawConfig)
+	if utils.IsEncrypted(newConfig.body) {
+		decryptedConfig, err := utils.Decrypt(newConfig.body)
 		if err != nil {
 			log.Println("Can't decrypt config")
 
-			return nil, nil
+			return nil
 		}
 
 		log.Println("Decrypted config")
 
-		newRawConfig = decryptedConfig
+		newConfig.body = decryptedConfig
 	}
+
+	if bytes.Equal(f.lastKnownConfig.body, newConfig.body) { // Only restart jobs if the new config differs from the current one
+		log.Println("The config has not changed. Keep calm and carry on!")
+
+		return nil
+	}
+
+	log.Println("New config received, applying")
 
 	var config Config
 
 	switch format {
 	case "", "json":
-		if err := json.Unmarshal(newRawConfig, &config); err != nil {
+		if err := json.Unmarshal(newConfig.body, &config); err != nil {
 			log.Printf("Failed to unmarshal job configs, will keep the current one: %v", err)
 
-			return nil, nil
+			return nil
 		}
 	case "yaml":
-		if err := yaml.Unmarshal(newRawConfig, &config); err != nil {
+		if err := yaml.Unmarshal(newConfig.body, &config); err != nil {
 			log.Printf("Failed to unmarshal job configs, will keep the current one: %v", err)
 
-			return nil, nil
+			return nil
 		}
 	default:
 		log.Printf("Unknown config format: %v", format)
 	}
 
-	return &config, newRawConfig
+	f.lastKnownConfig = *newConfig
+
+	return &config
 }


### PR DESCRIPTION
# Description

This will rely on `Last-Modified / If-Modified-Since` headers to see if remote config has changed. If these headers aren't available, it will try to use `Etag / If-None-Match` as fallback. If those aren't available either it will simply try to fetch whole file. This should result in less traffic to CDNs and will somewhat improve speed of fetching configs (to an extent).

This also fixes a bug where encrypted config was compared with decrypted `rawConfig`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested by running locally and in Docker.

## Logs

```text
01:39:37.373336 runner.go:155: The app has generated approximately 81347432 bytes of traffic
01:39:37.373605 runner.go:158: Of which for 37927 bytes we received some response from the target
01:39:37.566090 config.go:98: Received HTTP 304 Not Modified
01:39:37.566116 config.go:58: Loading config from "https://raw.githubusercontent.com/db1000n-coordinators/LoadTestConfig/main/config.v0.7.json"
01:39:37.566147 config.go:133: The config has not changed. Keep calm and carry on!
```