### PR TITLE
feat: added plain text proxy list parsing

### DIFF
--- a/src/utils/templates/templates.go
+++ b/src/utils/templates/templates.go
@@ -42,8 +42,18 @@ func getProxylistByURL(url string) (urls []string) {
 
 	defer resp.Body.Close()
 
-	if err = json.NewDecoder(resp.Body).Decode(&urls); err != nil {
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
 		return nil
+	}
+
+	err = json.Unmarshal(b, &urls)
+	if err != nil {
+		// try to parse response body as plain text with newline delimiter
+		urls = strings.Split(string(b), "\n")
+		if len(urls) == 0 {
+			return nil
+		}
 	}
 
 	return urls


### PR DESCRIPTION
# Description
now proxies urls can be provided not only as json array but as plain text delimited with newline(`\n`)
Fixes #282

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Run `go run main.go -c https://pastebin.com/raw/2WX69bsd`