### PR TITLE
Remove '304 Not Modified' to not cause confusion

### DIFF
--- a/src/runner/config/config.go
+++ b/src/runner/config/config.go
@@ -105,8 +105,6 @@ func (f *Fetcher) fetchSingle(path string) (*RawConfig, error) {
 	}
 
 	if resp.StatusCode == http.StatusNotModified {
-		log.Println("Received HTTP 304 Not Modified")
-
 		return &f.lastKnownConfig, nil
 	}
 


### PR DESCRIPTION
# Description

Seems like logging `Received HTTP 304 Not Modified` might be confusing. It's also somewhat redundant since app will log `The config has not changed. Keep calm and carry on!` anyway.

Related to https://github.com/Arriven/db1000n/issues/327

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)