### PR TITLE
Add "updater mode"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,6 @@ RUN apk add --update curl && rm  -rf /tmp/* /var/cache/apk/*
 WORKDIR /usr/src/app
 COPY --from=builder /build/db1000n .
 
+VOLUME /usr/src/app/config
+
 ENTRYPOINT ["./db1000n"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,12 +95,33 @@ services:
       interval: 30s
       retries: 3
 
+  # [OPTIONAL]
+  # run db1000n in updater mode, which will fetch configuration bypassing VPN and store it in shared volume
+  updater:
+    image: ghcr.io/arriven/db1000n
+    restart: unless-stopped
+    labels:
+      autoheal: "true"
+    entrypoint: "./db1000n --updater-mode"
+    volumes:
+      - ./config:/usr/src/app/config:z
+    healthcheck:
+      test: [ "CMD", "test", "-f", "config/config.json" ]
+      timeout: 5s
+      interval: 5s
+      retries: 5
+
   # this Docker container will use VPN 01
+  # it will use config.json created by 'updater' container above
+  # this is set by specifying same volume and -c config/config.json
   db1000n_01:
     image: ghcr.io/arriven/db1000n-advanced
     restart: unless-stopped
     depends_on:
-      - ovpn_01
+      ovpn_01:
+        condition: service_healthy
+      updater:
+        condition: service_healthy
     network_mode: "service:ovpn_01"
     labels:
         autoheal: "true"
@@ -108,6 +129,9 @@ services:
     environment:
       STRICT_COUNTRY_CHECK: "true"
       COUNTRY_LIST: "Country"
+      CONFIG: "config/config.json"
+    volumes:
+      - ./config:/usr/src/app/config:z
     healthcheck:
       test: [ "CMD", "nslookup", "google.com", "8.8.8.8" ]
       timeout: 10s
@@ -115,11 +139,16 @@ services:
       retries: 3
 
   # this Docker container will use VPN 02
+  # it will use config.json created by 'updater' container above
+  # this is set by specifying same volume and -c config/config.json
   db1000n_02:
     image: ghcr.io/arriven/db1000n-advanced
     restart: unless-stopped
     depends_on:
-      - ovpn_02
+      ovpn_02:
+        condition: service_healthy
+      updater:
+        condition: service_healthy
     network_mode: "service:ovpn_02"
     labels:
         autoheal: "true"
@@ -127,6 +156,9 @@ services:
     environment:
       STRICT_COUNTRY_CHECK: "true"
       COUNTRY_LIST: "Country, Another Country"
+      CONFIG: "config/config.json"
+    volumes:
+      - ./config:/usr/src/app/config:z
     healthcheck:
       test: [ "CMD", "nslookup", "google.com", "8.8.8.8" ]
       timeout: 10s
@@ -134,11 +166,13 @@ services:
       retries: 3
 
   # this Docker container will use VPN 03
+  # it will download config itself and won't access shared volume so those options are undefined here
   db1000n_03:
     image: ghcr.io/arriven/db1000n-advanced
     restart: unless-stopped
     depends_on:
-      - ovpn_03
+      ovpn_03:
+        condition: service_healthy
     network_mode: "service:ovpn_03"
     labels:
         autoheal: "true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,6 +105,8 @@ services:
     entrypoint: "./db1000n --updater-mode"
     volumes:
       - ./config:/usr/src/app/config:z
+    environment:
+      UPDATER_DESTINATION_CONFIG: "config/config.json"
     healthcheck:
       test: [ "CMD", "test", "-f", "config/config.json" ]
       timeout: 5s

--- a/main.go
+++ b/main.go
@@ -85,7 +85,7 @@ func main() {
 	configPathsArray := strings.Split(*configPaths, ",")
 
 	if *updaterMode {
-		updater.Run(configPathsArray)
+		updater.Run(configPathsArray, []byte(*backupConfig))
 
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -82,8 +82,10 @@ func main() {
 		return
 	}
 
+	configPathsArray := strings.Split(*configPaths, ",")
+
 	if *updaterMode {
-		updater.Run()
+		updater.Run(configPathsArray)
 
 		return
 	}
@@ -118,7 +120,7 @@ func main() {
 	}
 
 	r, err := runner.New(&runner.Config{
-		ConfigPaths:    *configPaths,
+		ConfigPaths:    configPathsArray,
 		BackupConfig:   []byte(*backupConfig),
 		RefreshTimeout: *refreshTimeout,
 		Format:         *configFormat,

--- a/main.go
+++ b/main.go
@@ -73,6 +73,7 @@ func main() {
 	strictCountryCheck := flag.Bool("strict-country-check", utils.GetEnvBoolDefault("STRICT_COUNTRY_CHECK", false), "enable strict country check; will also exit if IP can't be determined")
 	countryList := flag.String("country-list", utils.GetEnvStringDefault("COUNTRY_LIST", "Ukraine"), "comma-separated list of countries")
 	updaterMode := flag.Bool("updater-mode", utils.GetEnvBoolDefault("UPDATER_MODE", false), "Only run config updater")
+	destinationConfig := flag.String("updater-destination-config", utils.GetEnvStringDefault("UPDATER_DESTINATION_CONFIG", "config/config.json"), "Destination config file to write (only applies if updater-mode is enabled")
 
 	flag.Parse()
 
@@ -85,7 +86,7 @@ func main() {
 	configPathsArray := strings.Split(*configPaths, ",")
 
 	if *updaterMode {
-		updater.Run(configPathsArray, []byte(*backupConfig))
+		updater.Run(*destinationConfig, configPathsArray, []byte(*backupConfig))
 
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/Arriven/db1000n/src/utils/metrics"
 	"github.com/Arriven/db1000n/src/utils/ota"
 	"github.com/Arriven/db1000n/src/utils/templates"
+	"github.com/Arriven/db1000n/src/utils/updater"
 )
 
 const (
@@ -71,11 +72,18 @@ func main() {
 	autoUpdateCheckFrequency := flag.Duration("self-update-check-frequency", utils.GetEnvDurationDefault("SELF_UPDATE_CHECK_FREQUENCY", DefaultUpdateCheckFrequency), "How often to run auto-update checks")
 	strictCountryCheck := flag.Bool("strict-country-check", utils.GetEnvBoolDefault("STRICT_COUNTRY_CHECK", false), "enable strict country check; will also exit if IP can't be determined")
 	countryList := flag.String("country-list", utils.GetEnvStringDefault("COUNTRY_LIST", "Ukraine"), "comma-separated list of countries")
+	updaterMode := flag.Bool("updater-mode", utils.GetEnvBoolDefault("UPDATER_MODE", false), "Only run config updater")
 
 	flag.Parse()
 
 	if *help {
 		flag.CommandLine.Usage()
+
+		return
+	}
+
+	if *updaterMode {
+		updater.Run()
 
 		return
 	}

--- a/src/runner/config/config.go
+++ b/src/runner/config/config.go
@@ -2,7 +2,6 @@
 package config
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -31,26 +30,10 @@ type RawConfig struct {
 	etag         string
 }
 
-type Fetcher struct {
-	backupConfig    []byte
-	LastKnownConfig RawConfig
-}
-
-func NewFetcher(backupConfig []byte) *Fetcher {
-	return &Fetcher{
-		backupConfig: backupConfig,
-		LastKnownConfig: RawConfig{
-			Body:         nil,
-			lastModified: "",
-			etag:         "",
-		},
-	}
-}
-
 // fetch tries to read a config from the list of mirrors until it succeeds
-func (f *Fetcher) fetch(paths []string) *RawConfig {
+func fetch(paths []string, lastKnownConfig *RawConfig) *RawConfig {
 	for i := range paths {
-		config, err := f.fetchSingle(paths[i])
+		config, err := fetchSingle(paths[i], lastKnownConfig)
 		if err != nil {
 			log.Printf("Failed to fetch config from %q: %v", paths[i], err)
 
@@ -62,19 +45,11 @@ func (f *Fetcher) fetch(paths []string) *RawConfig {
 		return config
 	}
 
-	if f.LastKnownConfig.Body != nil {
-		log.Println("Could not load new config, proceeding with the last known good one")
-
-		return &f.LastKnownConfig
-	}
-
-	log.Println("Could not load new config, proceeding with the backup one")
-
-	return &RawConfig{Body: f.backupConfig, lastModified: "", etag: ""}
+	return lastKnownConfig
 }
 
 // fetchSingle reads a config from a single source
-func (f *Fetcher) fetchSingle(path string) (*RawConfig, error) {
+func fetchSingle(path string, lastKnownConfig *RawConfig) (*RawConfig, error) {
 	configURL, err := url.ParseRequestURI(path)
 	// absolute paths can be interpreted as a URL with no schema, need to check for that explicitly
 	if err != nil || filepath.IsAbs(path) {
@@ -96,8 +71,8 @@ func (f *Fetcher) fetchSingle(path string) (*RawConfig, error) {
 		return nil, err
 	}
 
-	req.Header.Add("If-None-Match", f.LastKnownConfig.etag)
-	req.Header.Add("If-Modified-Since", f.LastKnownConfig.lastModified)
+	req.Header.Add("If-None-Match", lastKnownConfig.etag)
+	req.Header.Add("If-Modified-Since", lastKnownConfig.lastModified)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -105,7 +80,7 @@ func (f *Fetcher) fetchSingle(path string) (*RawConfig, error) {
 	}
 
 	if resp.StatusCode == http.StatusNotModified {
-		return &f.lastKnownConfig, nil
+		return lastKnownConfig, nil
 	}
 
 	defer resp.Body.Close()
@@ -125,15 +100,15 @@ func (f *Fetcher) fetchSingle(path string) (*RawConfig, error) {
 	return &RawConfig{Body: res, etag: etag, lastModified: lastModified}, nil
 }
 
-func (f *Fetcher) UpdateWithoutUnmarshal(paths []string, format string) *RawConfig {
-	newConfig := f.fetch(paths)
+func FetchRawConfig(paths []string, lastKnownConfig *RawConfig) *RawConfig {
+	newConfig := fetch(paths, lastKnownConfig)
 
 	if utils.IsEncrypted(newConfig.Body) {
 		decryptedConfig, err := utils.Decrypt(newConfig.Body)
 		if err != nil {
 			log.Println("Can't decrypt config")
 
-			return nil
+			return lastKnownConfig
 		}
 
 		log.Println("Decrypted config")
@@ -141,20 +116,12 @@ func (f *Fetcher) UpdateWithoutUnmarshal(paths []string, format string) *RawConf
 		newConfig.Body = decryptedConfig
 	}
 
-	if bytes.Equal(f.LastKnownConfig.Body, newConfig.Body) { // Only restart jobs if the new config differs from the current one
-		log.Println("The config has not changed. Keep calm and carry on!")
-
-		return nil
-	}
-
 	return newConfig
 }
 
 // Update the job config from a list of paths or the built-in backup. Returns nil, nil in case of no changes.
-func (f *Fetcher) Update(paths []string, format string) *Config {
-	newConfig := f.UpdateWithoutUnmarshal(paths, format)
-
-	if newConfig == nil {
+func Unmarshal(body []byte, format string) *Config {
+	if body == nil {
 		return nil
 	}
 
@@ -164,13 +131,13 @@ func (f *Fetcher) Update(paths []string, format string) *Config {
 
 	switch format {
 	case "", "json":
-		if err := json.Unmarshal(newConfig.Body, &config); err != nil {
+		if err := json.Unmarshal(body, &config); err != nil {
 			log.Printf("Failed to unmarshal job configs, will keep the current one: %v", err)
 
 			return nil
 		}
 	case "yaml":
-		if err := yaml.Unmarshal(newConfig.Body, &config); err != nil {
+		if err := yaml.Unmarshal(body, &config); err != nil {
 			log.Printf("Failed to unmarshal job configs, will keep the current one: %v", err)
 
 			return nil
@@ -178,8 +145,6 @@ func (f *Fetcher) Update(paths []string, format string) *Config {
 	default:
 		log.Printf("Unknown config format: %v", format)
 	}
-
-	f.LastKnownConfig = *newConfig
 
 	return &config
 }

--- a/src/runner/runner.go
+++ b/src/runner/runner.go
@@ -18,7 +18,7 @@ import (
 
 // Config for the job runner
 type Config struct {
-	ConfigPaths    string            // Comma-separated config location URLs
+	ConfigPaths    []string          // Comma-separated config location URLs
 	BackupConfig   []byte            // Raw backup config
 	RefreshTimeout time.Duration     // How often to refresh config
 	Format         string            // json or yaml
@@ -40,7 +40,7 @@ type Runner struct {
 func New(cfg *Config, debug bool) (*Runner, error) {
 	return &Runner{
 		config:         cfg,
-		configPaths:    strings.Split(cfg.ConfigPaths, ","),
+		configPaths:    cfg.ConfigPaths,
 		configFetcher:  config.NewFetcher(cfg.BackupConfig),
 		refreshTimeout: cfg.RefreshTimeout,
 		configFormat:   cfg.Format,

--- a/src/utils/updater/updater.go
+++ b/src/utils/updater/updater.go
@@ -10,23 +10,23 @@ import (
 	"github.com/Arriven/db1000n/src/runner/config"
 )
 
-func Run(configPaths []string, backupConfig []byte) {
+func Run(destinationConfig string, configPaths []string, backupConfig []byte) {
 	lastKnownConfig := &config.RawConfig{Body: backupConfig}
 
 	for {
 		rawConfig := config.FetchRawConfig(configPaths, lastKnownConfig)
 
 		if !bytes.Equal(lastKnownConfig.Body, rawConfig.Body) {
-			file, err := os.Create("config/config.json")
+			file, err := os.Create(destinationConfig)
 			if err != nil {
-				log.Println("Unable to create config/config.json")
+				log.Printf("Unable to create %s", destinationConfig)
 
 				return
 			}
 
 			size, err := io.WriteString(file, string(rawConfig.Body))
 			if err != nil {
-				log.Println("Error while writing to config/config.json")
+				log.Printf("Error while writing to %s", destinationConfig)
 
 				return
 			}
@@ -35,7 +35,7 @@ func Run(configPaths []string, backupConfig []byte) {
 
 			lastKnownConfig = rawConfig
 
-			log.Printf("Saved config/config.json with size %d", size)
+			log.Printf("Saved %s with size %d", destinationConfig, size)
 		}
 
 		time.Sleep(1 * time.Minute)

--- a/src/utils/updater/updater.go
+++ b/src/utils/updater/updater.go
@@ -1,0 +1,88 @@
+package updater
+
+import (
+	"context"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+)
+
+func Run() {
+	const path = "https://raw.githubusercontent.com/db1000n-coordinators/LoadTestConfig/main/config.v0.7.json"
+
+	etag := ""
+	lastModified := ""
+	retries := 0
+
+	for {
+		configURL, err := url.ParseRequestURI(path)
+		if err != nil {
+			log.Fatal("Unable to parse URI")
+		}
+
+		const requestTimeout = 20 * time.Second
+
+		client := http.Client{
+			Timeout: requestTimeout,
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+		defer cancel()
+
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, configURL.String(), nil)
+		req.Header.Add("If-None-Match", etag)
+		req.Header.Add("If-Modified-Since", lastModified)
+
+		resp, err := client.Do(req)
+		if err != nil {
+			log.Println("Unable to perform HTTP request")
+
+			return
+		}
+
+		defer resp.Body.Close()
+
+		if resp.StatusCode >= http.StatusBadRequest {
+			log.Printf("Error fetching config, code %d", resp.StatusCode)
+
+			return
+		}
+
+		etag = resp.Header.Get("etag")
+		lastModified = resp.Header.Get("last-modified")
+
+		res, err := io.ReadAll(resp.Body)
+		if err != nil {
+			log.Println("Unable to read body")
+
+			return
+		}
+
+		if len(res) > 0 {
+			file, err := os.Create("config/config.json")
+			if err != nil {
+				log.Println("Unable to create config/config.json")
+
+				return
+			}
+
+			size, err := io.WriteString(file, string(res))
+			if err != nil {
+				log.Println("Error while writing to config/config.json")
+
+				return
+			}
+
+			defer file.Close()
+
+			log.Printf("Saved config/config.json with size %d", size)
+		}
+
+		retries++
+
+		time.Sleep(1 * time.Minute)
+	}
+}


### PR DESCRIPTION
# Description

This is mostly useful if you're running `db1000n` with docker-compose with VPN container. In this case you're likely to receive errors or time-outs while trying to update config file due to the fact that VPN connection is already highly saturated. Typically it looks like this:

```
runner.go:154: The app has generated approximately ... bytes of traffic
runner.go:157: Of which for ... bytes we received some response from the target
config.go:55: Failed to fetch config from "https://raw.github.com/.../config.json": Get unexpected EOF
config.go:66: Could not load new config, proceeding with the last known good one
config.go:148: The config has not changed. Keep calm and carry on!
```

Updater mode is a simple loop that will try fetching config file from remote server and store it in shared Docker volume. This is achieved by changing entrypoint to `--updater-mode` and mapping `./config` as shared volume to it. If any error is encountered, this process will exit and Docker will restart it. Healthcheck is checking for existence of this file, which means:

1) db1000n containers won't start until `updater` container pulled config first
2) If there are any other errors, `autohealer` will restart it

Normal `db1000n` containers will require two configuration changes:

1) Adding `./config` directory as shared volume so they can read configuration that is pulled by `updater` container
2) Change entrypoint to load config from file
3) Adding `updater` to their `depends_on` list so that they won't start until config file is available

The end result is such that `db1000n` container traffic is routed through VPN container tunnels but config update is routed outside VPN tunnel which means it's more likely to succeed.

I had to refactor a bunch of stuff in order to remove initial code duplication in `updater`. Probably easiest to follow commit by commit. The most important change is that `Fetcher` is removed and `lastKnownConfig` is simply passed through.

## Type of change

- [x] New feature (non-breaking change which adds functionality)