### PR TITLE
create empty cert pool if system one is unavailabe

### DIFF
--- a/src/utils/metrics/prometheus.go
+++ b/src/utils/metrics/prometheus.go
@@ -29,7 +29,6 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"errors"
-	"fmt"
 	"log"
 	"math/rand"
 	"net/http"
@@ -221,7 +220,7 @@ var PushGatewayCA string
 func getTLSConfig() (*tls.Config, error) {
 	rootCAs, err := x509.SystemCertPool()
 	if err != nil {
-		return nil, fmt.Errorf("can't get system cert pool: %w", err)
+		rootCAs = x509.NewCertPool()
 	}
 
 	if PushGatewayCA != "" {


### PR DESCRIPTION
# Description

use empty cert pool in prom if system one is unavailable (like on windows)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Test Configuration

- Release version:
- Platform:

## Logs

```text
logs
```

## Screenshots

- [ ] No screenshot
