### PR TITLE
Return country name from CheckCountry and send to Prometheus

### DIFF
--- a/main.go
+++ b/main.go
@@ -135,7 +135,9 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	clientID := uuid.NewString()
 	if *prometheusOn {
+		metrics.InitMetrics(clientID, country)
 		go metrics.ExportPrometheusMetrics(ctx, *prometheusPushGateways)
 	}
 
@@ -149,7 +151,7 @@ func main() {
 			ScaleFactor:   *scaleFactor,
 			SkipEncrypted: *skipEncrytedJobs,
 			Debug:         *debug,
-			ClientID:      uuid.NewString(),
+			ClientID:      clientID,
 		},
 	})
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -122,9 +122,12 @@ func main() {
 		templates.SetProxiesURL(*proxiesURL)
 	}
 
+	country := ""
+	isCountryAllowed := false
 	if *countryList != "" {
 		countries := strings.Split(*countryList, ",")
-		if !utils.CheckCountry(countries, *strictCountryCheck) {
+		isCountryAllowed, country = utils.CheckCountry(countries, *strictCountryCheck)
+		if !isCountryAllowed {
 			return
 		}
 	}

--- a/src/core/dnsblast/dns-blast.go
+++ b/src/core/dnsblast/dns-blast.go
@@ -54,7 +54,7 @@ func Start(ctx context.Context, logger *zap.Logger, wg *sync.WaitGroup, config *
 
 	nameservers, err := getNameservers(config.RootDomain, config.Protocol)
 	if err != nil {
-		metrics.IncDNSBlast(config.RootDomain, "", config.Protocol, metrics.StatusFail, config.ClientID)
+		metrics.IncDNSBlast(config.RootDomain, "", config.Protocol, metrics.StatusFail)
 
 		return fmt.Errorf("failed to resolve nameservers for the root domain [rootDomain=%s]: %w",
 			config.RootDomain, err)
@@ -84,7 +84,7 @@ func Start(ctx context.Context, logger *zap.Logger, wg *sync.WaitGroup, config *
 			defer utils.PanicHandler(logger)
 
 			if err := blaster.ExecuteStressTest(ctx, logger, nameserver, parameters, config.ClientID); err != nil {
-				metrics.IncDNSBlast(config.RootDomain, "", config.Protocol, metrics.StatusFail, config.ClientID)
+				metrics.IncDNSBlast(config.RootDomain, "", config.Protocol, metrics.StatusFail)
 				logger.Debug("stress test finished with error",
 					zap.String("nameserver", nameserver),
 					zap.String("proto", config.Protocol),
@@ -135,7 +135,7 @@ func (rcv *DNSBlaster) ExecuteStressTest(ctx context.Context, logger *zap.Logger
 
 	dhhGenerator, err := NewDistinctHeavyHitterGenerator(ctx, parameters.SeedDomains)
 	if err != nil {
-		metrics.IncDNSBlast(nameserver, "", parameters.Protocol, metrics.StatusFail, clientID)
+		metrics.IncDNSBlast(nameserver, "", parameters.Protocol, metrics.StatusFail)
 
 		return fmt.Errorf("failed to bootstrap the distinct heavy hitter generator: %w", err)
 	}
@@ -235,7 +235,7 @@ func (rcv *DNSBlaster) SimpleQueryWithNoResponse(logger *zap.Logger, sharedDNSCl
 	co, err := sharedDNSClient.Dial(parameters.HostAndPort)
 	if err != nil {
 		logger.Debug("failed to dial remote host to do the DNS query", zap.String("host", parameters.HostAndPort), zap.Error(err))
-		metrics.IncDNSBlast(parameters.HostAndPort, seedDomain, sharedDNSClient.Net, metrics.StatusFail, clientID)
+		metrics.IncDNSBlast(parameters.HostAndPort, seedDomain, sharedDNSClient.Net, metrics.StatusFail)
 
 		return
 	}
@@ -249,13 +249,13 @@ func (rcv *DNSBlaster) SimpleQueryWithNoResponse(logger *zap.Logger, sharedDNSCl
 
 	_, _, err = sharedDNSClient.Exchange(question, parameters.HostAndPort)
 	if err != nil {
-		metrics.IncDNSBlast(parameters.HostAndPort, seedDomain, sharedDNSClient.Net, metrics.StatusFail, clientID)
+		metrics.IncDNSBlast(parameters.HostAndPort, seedDomain, sharedDNSClient.Net, metrics.StatusFail)
 		logger.Debug("failed to complete the DNS query", zap.Error(err))
 
 		return
 	}
 
-	metrics.IncDNSBlast(parameters.HostAndPort, seedDomain, sharedDNSClient.Net, metrics.StatusSuccess, clientID)
+	metrics.IncDNSBlast(parameters.HostAndPort, seedDomain, sharedDNSClient.Net, metrics.StatusSuccess)
 }
 
 const (

--- a/src/core/slowloris/slowloris.go
+++ b/src/core/slowloris/slowloris.go
@@ -114,7 +114,7 @@ func (s SlowLoris) dialVictim(logger *zap.Logger, hostPort string, isTLS bool, c
 	// TODO: add support for dialing the Path via a random proxy from the given pool.
 	conn, err := net.Dial("tcp", hostPort)
 	if err != nil {
-		metrics.IncSlowLoris(hostPort, "tcp", metrics.StatusFail, clientID)
+		metrics.IncSlowLoris(hostPort, "tcp", metrics.StatusFail)
 		logger.Debug("couldn't establish connection", zap.String("addr", hostPort), zap.Error(err))
 
 		return nil
@@ -129,21 +129,21 @@ func (s SlowLoris) dialVictim(logger *zap.Logger, hostPort string, isTLS bool, c
 	const bufferSize = 128
 
 	if err = tcpConn.SetReadBuffer(bufferSize); err != nil {
-		metrics.IncSlowLoris(hostPort, "tcp", metrics.StatusFail, clientID)
+		metrics.IncSlowLoris(hostPort, "tcp", metrics.StatusFail)
 		logger.Debug("cannot shrink TCP read buffer", zap.Error(err))
 
 		return nil
 	}
 
 	if err = tcpConn.SetWriteBuffer(bufferSize); err != nil {
-		metrics.IncSlowLoris(hostPort, "tcp", metrics.StatusFail, clientID)
+		metrics.IncSlowLoris(hostPort, "tcp", metrics.StatusFail)
 		logger.Debug("cannot shrink TCP write buffer", zap.Error(err))
 
 		return nil
 	}
 
 	if err = tcpConn.SetLinger(0); err != nil {
-		metrics.IncSlowLoris(hostPort, "tcp", metrics.StatusFail, clientID)
+		metrics.IncSlowLoris(hostPort, "tcp", metrics.StatusFail)
 		logger.Debug("cannot disable TCP lingering", zap.Error(err))
 
 		return nil
@@ -158,7 +158,7 @@ func (s SlowLoris) dialVictim(logger *zap.Logger, hostPort string, isTLS bool, c
 	tlsConn := utls.UClient(tcpConn, &utls.Config{InsecureSkipVerify: true}, utls.HelloRandomized)
 
 	if err = tlsConn.Handshake(); err != nil {
-		metrics.IncSlowLoris(hostPort, "tcp", metrics.StatusFail, clientID)
+		metrics.IncSlowLoris(hostPort, "tcp", metrics.StatusFail)
 		conn.Close()
 		logger.Debug("couldn't establish tls connection", zap.String("addr", hostPort), zap.Error(err))
 
@@ -172,7 +172,7 @@ func (s SlowLoris) doLoris(logger *zap.Logger, config *Config, destinationHostPo
 	defer conn.Close()
 
 	if _, err := conn.Write(requestHeader); err != nil {
-		metrics.IncSlowLoris(destinationHostPort, "tcp", metrics.StatusFail, config.ClientID)
+		metrics.IncSlowLoris(destinationHostPort, "tcp", metrics.StatusFail)
 		logger.Debug("cannot write requestHeader", zap.ByteString("header", requestHeader), zap.Error(err))
 
 		return
@@ -192,13 +192,13 @@ func (s SlowLoris) doLoris(logger *zap.Logger, config *Config, destinationHostPo
 		}
 
 		if _, err := conn.Write(sharedWriteBuf); err != nil {
-			metrics.IncSlowLoris(destinationHostPort, "tcp", metrics.StatusFail, config.ClientID)
+			metrics.IncSlowLoris(destinationHostPort, "tcp", metrics.StatusFail)
 			logger.Debug("cannot write bytes", zap.Int("current", i), zap.Int("total", config.ContentLength), zap.Error(err))
 
 			return
 		}
 
-		metrics.IncSlowLoris(destinationHostPort, "tcp", metrics.StatusSuccess, config.ClientID)
+		metrics.IncSlowLoris(destinationHostPort, "tcp", metrics.StatusSuccess)
 	}
 }
 

--- a/src/jobs/http.go
+++ b/src/jobs/http.go
@@ -174,12 +174,12 @@ func fastHTTPJob(ctx context.Context, logger *zap.Logger, globalConfig GlobalCon
 
 func sendFastHTTPRequest(client *fasthttp.Client, req *fasthttp.Request, resp *fasthttp.Response, globalConfig GlobalConfig) error {
 	if err := client.Do(req, resp); err != nil {
-		metrics.IncHTTP(string(req.Host()), string(req.Header.Method()), metrics.StatusFail, globalConfig.ClientID)
+		metrics.IncHTTP(string(req.Host()), string(req.Header.Method()), metrics.StatusFail)
 
 		return err
 	}
 
-	metrics.IncHTTP(string(req.Host()), string(req.Header.Method()), metrics.StatusSuccess, globalConfig.ClientID)
+	metrics.IncHTTP(string(req.Host()), string(req.Header.Method()), metrics.StatusSuccess)
 
 	return nil
 }

--- a/src/jobs/rawnet.go
+++ b/src/jobs/rawnet.go
@@ -55,7 +55,7 @@ func sendTCP(ctx context.Context, logger *zap.Logger, jobConfig *rawnetConfig, g
 	conn, err := net.DialTCP("tcp", nil, tcpAddr)
 	if err != nil {
 		logger.Debug("error connecting via tcp", zap.Reflect("addr", tcpAddr), zap.Error(err))
-		metrics.IncRawnetTCP(tcpAddr.String(), metrics.StatusFail, globalConfig.ClientID)
+		metrics.IncRawnetTCP(tcpAddr.String(), metrics.StatusFail)
 
 		return
 	}
@@ -68,13 +68,13 @@ func sendTCP(ctx context.Context, logger *zap.Logger, jobConfig *rawnetConfig, g
 		trafficMonitor.Add(uint64(n))
 
 		if err != nil {
-			metrics.IncRawnetTCP(tcpAddr.String(), metrics.StatusFail, globalConfig.ClientID)
+			metrics.IncRawnetTCP(tcpAddr.String(), metrics.StatusFail)
 
 			return
 		}
 
 		processedTrafficMonitor.Add(uint64(n))
-		metrics.IncRawnetTCP(tcpAddr.String(), metrics.StatusSuccess, globalConfig.ClientID)
+		metrics.IncRawnetTCP(tcpAddr.String(), metrics.StatusSuccess)
 	}
 }
 
@@ -100,7 +100,7 @@ func udpJob(ctx context.Context, logger *zap.Logger, globalConfig GlobalConfig, 
 	conn, err := net.DialUDP("udp", nil, udpAddr)
 	if err != nil {
 		logger.Debug("error connecting via tcp", zap.Reflect("addr", udpAddr), zap.Error(err))
-		metrics.IncRawnetUDP(udpAddr.String(), metrics.StatusFail, globalConfig.ClientID)
+		metrics.IncRawnetUDP(udpAddr.String(), metrics.StatusFail)
 
 		return nil, err
 	}
@@ -117,13 +117,13 @@ func udpJob(ctx context.Context, logger *zap.Logger, globalConfig GlobalConfig, 
 func sendUDP(ctx context.Context, logger *zap.Logger, a *net.UDPAddr, conn *net.UDPConn, bodyTpl *template.Template, globalConfig GlobalConfig, trafficMonitor *metrics.Writer) {
 	n, err := conn.Write([]byte(templates.Execute(logger, bodyTpl, ctx)))
 	if err != nil {
-		metrics.IncRawnetUDP(a.String(), metrics.StatusFail, globalConfig.ClientID)
+		metrics.IncRawnetUDP(a.String(), metrics.StatusFail)
 
 		return
 	}
 
 	trafficMonitor.Add(uint64(n))
-	metrics.IncRawnetUDP(a.String(), metrics.StatusSuccess, globalConfig.ClientID)
+	metrics.IncRawnetUDP(a.String(), metrics.StatusSuccess)
 }
 
 func parseRawNetJobArgs(ctx context.Context, logger *zap.Logger, args Args) (tpl *rawnetConfig, err error) {

--- a/src/runner/runner.go
+++ b/src/runner/runner.go
@@ -52,7 +52,7 @@ func New(cfg *Config) (*Runner, error) {
 func (r *Runner) Run(ctx context.Context, logger *zap.Logger) {
 	clientID := uuid.MustParse(r.config.Global.ClientID)
 
-	metrics.IncClient(clientID.String())
+	metrics.IncClient()
 
 	refreshTimer := time.NewTicker(r.refreshTimeout)
 

--- a/src/utils/countrychecker.go
+++ b/src/utils/countrychecker.go
@@ -11,7 +11,7 @@ import (
 )
 
 // CheckCountry allows to check which country the app is running from
-func CheckCountry(countriesToAvoid []string, strictCountryCheck bool) bool {
+func CheckCountry(countriesToAvoid []string, strictCountryCheck bool) (bool, string) {
 	type IPInfo struct {
 		Country string `json:"country"`
 		IP      string `json:"ip"`
@@ -73,10 +73,10 @@ func CheckCountry(countriesToAvoid []string, strictCountryCheck bool) bool {
 		if strictCountryCheck {
 			log.Println("Strict country check mode is enabled, exiting")
 
-			return false
+			return false, ""
 		}
 
-		return true
+		return true, ""
 	}
 
 	for _, country := range countriesToAvoid {
@@ -87,14 +87,14 @@ func CheckCountry(countriesToAvoid []string, strictCountryCheck bool) bool {
 			if strictCountryCheck {
 				log.Println("Strict country check mode is enabled, exiting")
 
-				return false
+				return false, ipInfo.Country
 			}
 
-			return true
+			return true, ipInfo.Country
 		}
 	}
 
 	log.Printf("Current country: %s (%s)", ipInfo.Country, ipInfo.IP)
 
-	return true
+	return true, ipInfo.Country
 }

--- a/src/utils/metrics/prometheus.go
+++ b/src/utils/metrics/prometheus.go
@@ -84,41 +84,61 @@ const (
 
 // Client related values and labels
 const (
-	ClientIDLabel = "id"
+	ClientIDLabel = `id`
+	CountryLabel  = `country`
 )
 
 // registered metrics
 var (
+	dnsBlastCounter  *prometheus.CounterVec = nil
+	httpCounter      *prometheus.CounterVec = nil
+	packetgenCounter *prometheus.CounterVec = nil
+	slowlorisCounter *prometheus.CounterVec = nil
+	rawnetCounter    *prometheus.CounterVec = nil
+	clientCounter    *prometheus.CounterVec = nil
+)
+
+func InitMetrics(clientID, country string) {
+	constLabels := prometheus.Labels{ClientIDLabel: clientID}
+	if country != "" {
+		constLabels[CountryLabel] = country
+	}
 	dnsBlastCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "db1000n_dns_blast_total",
-			Help: "Number of dns queries",
-		}, []string{DNSBlastRootDomainLabel, DNSBlastSeedDomainLabel, DNSBlastProtocolLabel, StatusLabel, ClientIDLabel})
+			Name:        "db1000n_dns_blast_total",
+			Help:        "Number of dns queries",
+			ConstLabels: constLabels,
+		}, []string{DNSBlastRootDomainLabel, DNSBlastSeedDomainLabel, DNSBlastProtocolLabel, StatusLabel})
 	httpCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "db1000n_http_request_total",
-			Help: "Number of http queries",
-		}, []string{HTTPDestinationHostLabel, HTTPMethodLabel, StatusLabel, ClientIDLabel})
+			Name:        "db1000n_http_request_total",
+			Help:        "Number of http queries",
+			ConstLabels: constLabels,
+		}, []string{HTTPDestinationHostLabel, HTTPMethodLabel, StatusLabel})
 	packetgenCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "db1000n_packetgen_total",
-			Help: "Number of packet generation transfers",
-		}, []string{PacketgenHostLabel, PacketgenDstHostPortLabel, PacketgenProtocolLabel, StatusLabel, ClientIDLabel})
+			Name:        "db1000n_packetgen_total",
+			Help:        "Number of packet generation transfers",
+			ConstLabels: constLabels,
+		}, []string{PacketgenHostLabel, PacketgenDstHostPortLabel, PacketgenProtocolLabel, StatusLabel})
 	slowlorisCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "db1000n_slowloris_total",
-			Help: "Number of sent raw tcp/udp packets",
-		}, []string{SlowlorisAddressLabel, SlowlorisProtocolLabel, StatusLabel, ClientIDLabel})
+			Name:        "db1000n_slowloris_total",
+			Help:        "Number of sent raw tcp/udp packets",
+			ConstLabels: constLabels,
+		}, []string{SlowlorisAddressLabel, SlowlorisProtocolLabel, StatusLabel})
 	rawnetCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "db1000n_rawnet_total",
-			Help: "Number of sent raw tcp/udp packets",
-		}, []string{RawnetAddressLabel, RawnetProtocolLabel, StatusLabel, ClientIDLabel})
+			Name:        "db1000n_rawnet_total",
+			Help:        "Number of sent raw tcp/udp packets",
+			ConstLabels: constLabels,
+		}, []string{RawnetAddressLabel, RawnetProtocolLabel, StatusLabel})
 	clientCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "db1000n_client_total",
-		Help: "Number of clients",
-	}, []string{ClientIDLabel})
-)
+		Name:        "db1000n_client_total",
+		Help:        "Number of clients",
+		ConstLabels: constLabels,
+	}, []string{})
+}
 
 func registerMetrics() {
 	prometheus.MustRegister(dnsBlastCounter)
@@ -289,23 +309,21 @@ func pushMetrics(ctx context.Context, gateways []string) {
 }
 
 // IncDNSBlast increments counter of sent dns queries
-func IncDNSBlast(rootDomain, seedDomain, protocol, status, id string) {
+func IncDNSBlast(rootDomain, seedDomain, protocol, status string) {
 	dnsBlastCounter.With(prometheus.Labels{
 		DNSBlastRootDomainLabel: rootDomain,
 		DNSBlastSeedDomainLabel: seedDomain,
 		DNSBlastProtocolLabel:   protocol,
 		StatusLabel:             status,
-		ClientIDLabel:           id,
 	}).Inc()
 }
 
 // IncHTTP increments counter of sent http queries
-func IncHTTP(host, method, status, id string) {
+func IncHTTP(host, method, status string) {
 	httpCounter.With(prometheus.Labels{
 		HTTPMethodLabel:          method,
 		HTTPDestinationHostLabel: host,
 		StatusLabel:              status,
-		ClientIDLabel:            id,
 	}).Inc()
 }
 
@@ -321,37 +339,32 @@ func IncPacketgen(host, hostPort, protocol, status, id string) {
 }
 
 // IncSlowLoris increments counter of sent raw ethernet+ip+tcp/udp packets
-func IncSlowLoris(address, protocol, status, id string) {
+func IncSlowLoris(address, protocol, status string) {
 	slowlorisCounter.With(prometheus.Labels{
 		SlowlorisAddressLabel:  address,
 		SlowlorisProtocolLabel: protocol,
 		StatusLabel:            status,
-		ClientIDLabel:          id,
 	}).Inc()
 }
 
 // IncRawnetTCP increments counter of sent raw tcp packets
-func IncRawnetTCP(address, status, id string) {
+func IncRawnetTCP(address, status string) {
 	rawnetCounter.With(prometheus.Labels{
 		RawnetAddressLabel:  address,
 		RawnetProtocolLabel: "tcp",
 		StatusLabel:         status,
-		ClientIDLabel:       id,
 	}).Inc()
 }
 
 // IncRawnetUDP increments counter of sent raw tcp packets
-func IncRawnetUDP(address, status, id string) {
+func IncRawnetUDP(address, status string) {
 	rawnetCounter.With(prometheus.Labels{
 		RawnetAddressLabel:  address,
 		RawnetProtocolLabel: "udp",
 		StatusLabel:         status,
-		ClientIDLabel:       id,
 	}).Inc()
 }
 
-func IncClient(id string) {
-	clientCounter.With(prometheus.Labels{
-		ClientIDLabel: id,
-	}).Inc()
+func IncClient() {
+	clientCounter.With(prometheus.Labels{}).Inc()
 }


### PR DESCRIPTION
# Description

- Pass ClientID as const label for Prometheus
- Return country name from CheckCountry function
- Add country name to Prometheus metrics

This is useful if you're using Prometheus / Grafana to monitor overall performance.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
