### PR TITLE
Added proxy URL validation and socks5 support for rawnet job type (#279)

### DIFF
--- a/main.go
+++ b/main.go
@@ -117,6 +117,13 @@ func main() {
 		log.Fatal("Invalid value for --prometheus_gateways")
 	}
 
+	if *systemProxy != "" {
+		_, err = utils.ParseProxyUrl(*systemProxy)
+		if err != nil {
+			log.Fatalf("Invalid value for --proxy: %v", err)
+		}
+	}
+
 	country := ""
 
 	var isCountryAllowed bool

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/url"
 	"os"
 	"os/exec"
 	"runtime"
@@ -122,4 +123,18 @@ func OpenBrowser(url string) {
 	}
 
 	log.Printf("Please open %s", url)
+}
+
+func ParseProxyUrl(proxyAddr string) (*url.URL, error) {
+	if proxyAddr != "" {
+		u, err := url.Parse(proxyAddr)
+		if err != nil {
+			return nil, err
+		}
+		switch u.Scheme {
+		case "socks5", "socks5h", "http":
+			return u, nil
+		}
+	}
+	return nil, fmt.Errorf("invalid scheme, should be one of http:// or socks5://")
 }


### PR DESCRIPTION
See description of CR here #279

It's still not work for udp type jobs
"msg":"error running job","error":"socks connect udp 172.17.0.1:9150->1.2.3.4:53: network not implemented"
because socks5 library is not support udp for now. But I am decided to leave it as is because when you will run it through proxy - you expect that it it should go through proxy and, probably, you don't want to get abuse messages to yours workloads.