### PR TITLE
allow using socks5 proxy in tcp jobs

### DIFF
--- a/src/jobs/http.go
+++ b/src/jobs/http.go
@@ -45,7 +45,7 @@ func singleRequestJob(ctx context.Context, logger *zap.Logger, globalConfig Glob
 		clientConfig.ProxyURLs = templates.ParseAndExecute(logger, globalConfig.ProxyURLs, ctx)
 	}
 
-	client := http.NewClient(clientConfig, logger)
+	client := http.NewClient(ctx, clientConfig, logger)
 
 	var requestConfig http.RequestConfig
 	if err := utils.Decode(templates.ParseAndExecuteMapStruct(logger, jobConfig.Request, ctx), &requestConfig); err != nil {
@@ -128,7 +128,7 @@ func fastHTTPJob(ctx context.Context, logger *zap.Logger, globalConfig GlobalCon
 		clientConfig.ProxyURLs = templates.ParseAndExecute(logger, globalConfig.ProxyURLs, ctx)
 	}
 
-	client := http.NewClient(clientConfig, logger)
+	client := http.NewClient(ctx, clientConfig, logger)
 
 	requestTpl, err := templates.ParseMapStruct(jobConfig.Request)
 	if err != nil {

--- a/src/utils/proxy.go
+++ b/src/utils/proxy.go
@@ -1,0 +1,34 @@
+package utils
+
+import (
+	"math/rand"
+	"net"
+	"net/url"
+	"strings"
+	"time"
+
+	"golang.org/x/net/proxy"
+)
+
+type ProxyFunc func(network, addr string) (net.Conn, error)
+
+func GetProxyFunc(proxyURLs string, timeout time.Duration) ProxyFunc {
+	direct := &net.Dialer{Timeout: timeout}
+	if proxyURLs == "" {
+		return proxy.FromEnvironmentUsing(direct).Dial
+	}
+
+	proxies := strings.Split(proxyURLs, ",")
+
+	u, err := url.Parse(proxies[rand.Intn(len(proxies))]) //nolint:gosec // Cryptographically secure random not required
+	if err != nil {
+		return proxy.FromEnvironmentUsing(direct).Dial
+	}
+
+	client, err := proxy.FromURL(u, direct)
+	if err != nil {
+		return proxy.FromEnvironmentUsing(direct).Dial
+	}
+
+	return client.Dial
+}

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -83,6 +83,22 @@ func GetEnvDurationDefault(key string, defaultValue time.Duration) time.Duration
 	return v
 }
 
+func NonNilDurationOrDefault(d *time.Duration, dflt time.Duration) time.Duration {
+	if d != nil {
+		return *d
+	}
+
+	return dflt
+}
+
+func NonNilIntOrDefault(i *int, dflt int) int {
+	if i != nil {
+		return *i
+	}
+
+	return dflt
+}
+
 // Decode is an alias to a mapstructure.NewDecoder({Squash: true}).Decode()
 func Decode(input interface{}, output interface{}) error {
 	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{Squash: true, WeaklyTypedInput: true, Result: output})


### PR DESCRIPTION
# Description

Allow using socks5 proxy in tcp jobs. Inspired by #381

WIP #279 

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Test Configuration

- Release version:
- Platform:

## Logs

```text
logs
```

## Screenshots

- [ ] No screenshot
