### PR TITLE
Avoid app crash with -prometheus_on=false

### DIFF
--- a/src/utils/metrics/prometheus.go
+++ b/src/utils/metrics/prometheus.go
@@ -97,6 +97,7 @@ var (
 	clientCounter    *prometheus.CounterVec
 )
 
+// InitMetrics initializes prometheus counters
 func InitMetrics(clientID, country string) {
 	constLabels := prometheus.Labels{ClientIDLabel: clientID}
 	if country != "" {
@@ -284,6 +285,10 @@ func pushMetrics(ctx context.Context, gateways []string) {
 
 // IncDNSBlast increments counter of sent dns queries
 func IncDNSBlast(rootDomain, seedDomain, protocol, status string) {
+	if dnsBlastCounter == nil {
+		return
+	}
+
 	dnsBlastCounter.With(prometheus.Labels{
 		DNSBlastRootDomainLabel: rootDomain,
 		DNSBlastSeedDomainLabel: seedDomain,
@@ -294,6 +299,10 @@ func IncDNSBlast(rootDomain, seedDomain, protocol, status string) {
 
 // IncHTTP increments counter of sent http queries
 func IncHTTP(host, method, status string) {
+	if httpCounter == nil {
+		return
+	}
+
 	httpCounter.With(prometheus.Labels{
 		HTTPMethodLabel:          method,
 		HTTPDestinationHostLabel: host,
@@ -303,6 +312,10 @@ func IncHTTP(host, method, status string) {
 
 // IncPacketgen increments counter of sent raw packets
 func IncPacketgen(host, hostPort, protocol, status, id string) {
+	if packetgenCounter == nil {
+		return
+	}
+
 	packetgenCounter.With(prometheus.Labels{
 		PacketgenHostLabel:        host,
 		PacketgenDstHostPortLabel: hostPort,
@@ -314,6 +327,10 @@ func IncPacketgen(host, hostPort, protocol, status, id string) {
 
 // IncSlowLoris increments counter of sent raw ethernet+ip+tcp/udp packets
 func IncSlowLoris(address, protocol, status string) {
+	if slowlorisCounter == nil {
+		return
+	}
+
 	slowlorisCounter.With(prometheus.Labels{
 		SlowlorisAddressLabel:  address,
 		SlowlorisProtocolLabel: protocol,
@@ -323,6 +340,10 @@ func IncSlowLoris(address, protocol, status string) {
 
 // IncRawnetTCP increments counter of sent raw tcp packets
 func IncRawnetTCP(address, status string) {
+	if rawnetCounter == nil {
+		return
+	}
+
 	rawnetCounter.With(prometheus.Labels{
 		RawnetAddressLabel:  address,
 		RawnetProtocolLabel: "tcp",
@@ -332,6 +353,10 @@ func IncRawnetTCP(address, status string) {
 
 // IncRawnetUDP increments counter of sent raw tcp packets
 func IncRawnetUDP(address, status string) {
+	if rawnetCounter == nil {
+		return
+	}
+
 	rawnetCounter.With(prometheus.Labels{
 		RawnetAddressLabel:  address,
 		RawnetProtocolLabel: "udp",
@@ -339,6 +364,11 @@ func IncRawnetUDP(address, status string) {
 	}).Inc()
 }
 
+// IncClient increments counter of calls from the current client ID
 func IncClient() {
+	if clientCounter == nil {
+		return
+	}
+
 	clientCounter.With(prometheus.Labels{}).Inc()
 }


### PR DESCRIPTION
# Description

Prometheus counters are created only upon the call to ``InitMetrics`` (e.g. with ``prometheus_on=true``), but are still accessed always. This leads to the app crash with ``prometheus_on=false``.

Fix: add nil-checks before incrementing the counters.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Run the app with ``prometheus_on=false`` before and after the fix.
## Test Configuration

- Release version: 0.8.0
- Platform: Fedora 35

## Logs

### Before
```text
% ./db1000n -prometheus_on=false

2022/03/21 12:20:20.052206 main.go:57: DB1000n [Version: v0.0.1][PID=11808]
2022/03/21 12:20:20.052444 countrychecker.go:28: Checking IP address, attempt #0
2022/03/21 12:20:21.480148 countrychecker.go:97: Current country: XXX
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xa23e26]

goroutine 1 [running]:
github.com/prometheus/client_golang/prometheus.(*CounterVec).GetMetricWith(...)
	/home/XXX/go/pkg/mod/github.com/prometheus/client_golang@v1.12.1/prometheus/counter.go:238
github.com/prometheus/client_golang/prometheus.(*CounterVec).With(0x0, 0xc0006f5560, 0x3045492573799206, 0x43a22ae866d53286)
	/home/XXX/go/pkg/mod/github.com/prometheus/client_golang@v1.12.1/prometheus/counter.go:261 +0x26
github.com/Arriven/db1000n/src/utils/metrics.IncClient()
	/home/XXX/Projects/github/db1000n/src/utils/metrics/prometheus.go:343 +0x3e
github.com/Arriven/db1000n/src/runner.(*Runner).Run(0xc0004172c0, 0xeeb3e0, 0xc0006f5530, 0xc00012c2a0)
	/home/XXX/Projects/github/db1000n/src/runner/runner.go:56 +0x106
main.main()
	/home/XXX/Projects/github/db1000n/main.go:174 +0xfbf

```

### After
```
% ./db1000n -prometheus_on=false
2022/03/21 12:35:13.647562 main.go:57: DB1000n [Version: v0.0.1][PID=12778]
2022/03/21 12:35:13.648182 countrychecker.go:28: Checking IP address, attempt #0
2022/03/21 12:35:15.371262 countrychecker.go:97: Current country: XXX
2022/03/21 12:35:15.444962 config.go:40: Loading config from "https://raw.githubusercontent.com/db1000n-coordinators/LoadTestConfig/main/config.v0.7.json"
2022/03/21 12:35:15.445041 config.go:125: New config received, applying
2022/03/21 12:35:15.447991 runner.go:153: 14 job instances (re)started
```
## Screenshots

- [x] No screenshot
