### PR TITLE
DB1000N | Add support for the restart option after the auto-update for the Windows OS

### DIFF
--- a/main.go
+++ b/main.go
@@ -99,7 +99,10 @@ func main() {
 
 	logger, err := newZapLogger(*debug)
 	if err != nil {
-		log.Fatal("failed to create zap logger", err)
+		log.Printf("failed to initialize Zap logger: %s", err)
+		os.Exit(1)
+
+		return
 	}
 
 	configPathsArray := strings.Split(*configPaths, ",")

--- a/src/utils/ota/ota.go
+++ b/src/utils/ota/ota.go
@@ -43,20 +43,3 @@ func MockAutoUpdate(shouldUpdateBeFound bool) (updateFound bool, newVersion, cha
 
 	return
 }
-
-func appendArgIfNotPresent(osArgs, extraArgs []string) []string {
-	osArgsMap := make(map[string]interface{}, len(osArgs))
-	for _, osArg := range osArgs {
-		osArgsMap[osArg] = nil
-	}
-
-	acceptedExtraArgs := make([]string, 0)
-
-	for _, extraArg := range extraArgs {
-		if _, isAlreadyOSArg := osArgsMap[extraArg]; !isAlreadyOSArg {
-			acceptedExtraArgs = append(acceptedExtraArgs, extraArg)
-		}
-	}
-
-	return append(osArgs, acceptedExtraArgs...)
-}

--- a/src/utils/ota/restart.go
+++ b/src/utils/ota/restart.go
@@ -1,10 +1,13 @@
-//go:build windows || netbsd || solaris || aix || dragonfly || freebsd || (illumos && !linux && !darwin)
-// +build windows netbsd solaris aix dragonfly freebsd illumos,!linux,!darwin
+//go:build !linux && !darwin && !windows
+// +build !linux,!darwin,!windows
 
 package ota
 
-import "errors"
+import (
+	"fmt"
+	"runtime"
+)
 
 func Restart(extraArgs ...string) error {
-	return errors.New("restart on the Windows system is not available")
+	return fmt.Errorf("restart on the %s system is not available", runtime.GOOS)
 }

--- a/src/utils/ota/restart_windows.go
+++ b/src/utils/ota/restart_windows.go
@@ -1,0 +1,46 @@
+//go:build windows
+// +build windows
+
+package ota
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+)
+
+func Restart(extraArgs ...string) error {
+	execPath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("failed to locate the executable file: %w", err)
+	}
+
+	// A specific way the `cmd.exe` processes the `start` command: it takes the
+	// first quoted substring as a process name! (https://superuser.com/a/1656458)
+	cmdLine := fmt.Sprintf(`/C start "process" "%s"`, execPath)
+	args := []string{}
+
+	if len(extraArgs) != 0 {
+		args = appendArgIfNotPresent(os.Args[1:], extraArgs)
+	} else {
+		args = os.Args[1:]
+	}
+
+	if len(args) > 0 {
+		cmdLine += " " + strings.Join(args, " ")
+	}
+
+	cmd := exec.Command("cmd.exe")
+	cmd.SysProcAttr = &syscall.SysProcAttr{CmdLine: cmdLine}
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to start the command: %w", err)
+	}
+
+	os.Exit(0)
+
+	return nil
+}
+

--- a/src/utils/ota/restart_windows.go
+++ b/src/utils/ota/restart_windows.go
@@ -35,7 +35,7 @@ func Restart(extraArgs ...string) error {
 	cmd := exec.Command("cmd.exe")
 	cmd.SysProcAttr = &syscall.SysProcAttr{CmdLine: cmdLine}
 
-	if err := cmd.Run(); err != nil {
+	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("failed to start the command: %w", err)
 	}
 

--- a/src/utils/ota/shared.go
+++ b/src/utils/ota/shared.go
@@ -1,0 +1,18 @@
+package ota
+
+func appendArgIfNotPresent(osArgs, extraArgs []string) []string {
+	osArgsMap := make(map[string]interface{}, len(osArgs))
+	for _, osArg := range osArgs {
+		osArgsMap[osArg] = nil
+	}
+
+	acceptedExtraArgs := make([]string, 0)
+
+	for _, extraArg := range extraArgs {
+		if _, isAlreadyOSArg := osArgsMap[extraArg]; !isAlreadyOSArg {
+			acceptedExtraArgs = append(acceptedExtraArgs, extraArg)
+		}
+	}
+
+	return append(osArgs, acceptedExtraArgs...)
+}

--- a/src/utils/ota/shared_test.go
+++ b/src/utils/ota/shared_test.go
@@ -1,6 +1,3 @@
-//go:build linux
-// +build linux
-
 package ota
 
 import (


### PR DESCRIPTION
## Restart the needle once the auto-update has finished on the Windows OS
(Codename: `Glory to Those who protect the Land`)

This patch brings the restart the option for the DB1000N on the OS with non-boring wallpapers.

Take care and stay safe, folks!

### References
1. https://github.com/golang/go/issues/29841
2. https://superuser.com/a/1656458
