### PR TITLE
allow sending http flood to static host

### DIFF
--- a/config/examples/http-host.yaml
+++ b/config/examples/http-host.yaml
@@ -1,0 +1,9 @@
+jobs:
+  - type: http
+    args:
+      request:
+        method: GET
+        path: http://lolkek/test
+      client:
+        static_host:
+          addr: 127.0.0.1:8080

--- a/src/jobs/http.go
+++ b/src/jobs/http.go
@@ -194,7 +194,7 @@ func fastHTTPJob(ctx context.Context, logger *zap.Logger, globalConfig GlobalCon
 	return nil, nil
 }
 
-func sendFastHTTPRequest(client *fasthttp.Client, req *fasthttp.Request, resp *fasthttp.Response) error {
+func sendFastHTTPRequest(client http.Client, req *fasthttp.Request, resp *fasthttp.Response) error {
 	if err := client.Do(req, resp); err != nil {
 		metrics.IncHTTP(string(req.Host()), string(req.Header.Method()), metrics.StatusFail)
 


### PR DESCRIPTION
# Description

Allow sending http traffic to a predefined host different from a url one to prevent dns re-targeting

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Test Configuration

- Release version:
- Platform:

## Logs

```text
logs
```

## Screenshots

- [ ] No screenshot
