### PR TITLE
terraform: Added arm support for aws

### DIFF
--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -16,7 +16,7 @@ data "aws_ami" "latest_amazon_linux" {
   most_recent = true
   filter {
     name   = "name"
-    values = ["amzn2-ami-kernel-*-hvm-*-x86_64-gp2"]
+    values = ["amzn2-ami-kernel-*-hvm-*-${var.arch_ami}-gp2"]
   }
 }
 

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -9,10 +9,17 @@ variable "name" {
   description = "name of deployment"
 }
 
+variable "arch_ami" {
+  type        = string
+  description = "architecture of the ami"
+  default     = "arm64"
+}
+
+
 variable "instance_type" {
   type        = string
   description = "Instance type"
-  default     = "t2.micro"
+  default     = "t4g.micro"
 }
 
 variable "max_size" {


### PR DESCRIPTION
# Description

Added arm instance type and ami for the aws terraform configuration.
arm instance is more performant and cheaper than regular non graviton instances.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] tested with terraform plan, it takes right ami, since db1000n has arm support, it should work. 
- [ ] Test B


