### PR TITLE
[DRAFT] Add load balanced tor proxy to AWS terraform config

### DIFF
--- a/terraform/aws/ireland.tfvars
+++ b/terraform/aws/ireland.tfvars
@@ -1,6 +1,7 @@
 # Make changes in this file
 region           = "eu-west-1"
-name             = "ir_db1000n"
+name             = "ir-db1000n"
 desired_capacity = 2
 min_size         = 0
 max_size         = 32
+zones            = 2

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -116,7 +116,8 @@ resource "aws_route_table" "route-table-test-env" {
 }
 
 resource "aws_route_table_association" "subnet-association" {
-  subnet_id      = aws_subnet.main.id
+  for_each       = { for az, subnet in aws_subnet.main : az => subnet.id }
+  subnet_id      = each.value
   route_table_id = aws_route_table.route-table-test-env.id
 }
 
@@ -136,7 +137,8 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
     service docker start
     usermod -a -G docker ec2-user
     chkconfig docker on
-    docker run  -ti -d --restart always ghcr.io/arriven/db1000n-advanced
+    PIPS=$(host -4 ${aws_lb.proxy-lb.dns_name} | egrep -o '[0-9]+(\.[0-9]+){3}$' | awk '{printf("socks5://%s:9050\n", $0)}' | paste -d',' -s -)
+    docker run -ti -d --restart always ghcr.io/arriven/db1000n-advanced ./db1000n -proxy $PIPS
 
 EOF
   )
@@ -162,6 +164,7 @@ EOF
       Name = "db1000n-server"
     }
   }
+  depends_on = [aws_lb.proxy-lb]
 }
 
 resource "aws_autoscaling_group" "example" {
@@ -170,7 +173,7 @@ resource "aws_autoscaling_group" "example" {
   desired_capacity          = var.desired_capacity
   max_size                  = var.max_size
   min_size                  = var.min_size
-  vpc_zone_identifier       = [aws_subnet.main.id]
+  vpc_zone_identifier       = [for subnet in aws_subnet.main : subnet.id]
   health_check_grace_period = 180
   launch_template {
     id      = aws_launch_template.example.id
@@ -185,7 +188,197 @@ resource "aws_vpc" "main" {
 }
 
 resource "aws_subnet" "main" {
+  for_each                = { for azid, zone in slice(data.aws_availability_zones.azs.names, 0, var.zones) : zone => azid }
+  availability_zone       = each.key
   vpc_id                  = aws_vpc.main.id
-  cidr_block              = "10.0.1.0/24"
+  cidr_block              = cidrsubnet(aws_vpc.main.cidr_block, 8, var.zones + each.value)
   map_public_ip_on_launch = true
+}
+
+# >>> proxy
+
+data "aws_availability_zones" "azs" {
+  state = "available"
+}
+
+resource "aws_subnet" "private" {
+  for_each                = { for azid, zone in slice(data.aws_availability_zones.azs.names, 0, var.zones) : zone => azid }
+  availability_zone       = each.key
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = cidrsubnet(aws_vpc.main.cidr_block, 8, 0 + each.value)
+  map_public_ip_on_launch = false
+}
+
+resource "aws_lb" "proxy-lb" {
+  name               = "${var.name}-proxy"
+  internal           = true
+  load_balancer_type = "network"
+  #  security_groups    = [aws_security_group.lb.id]
+  subnets = [for subnet in aws_subnet.private : subnet.id]
+}
+
+resource "aws_lb_target_group" "proxy-lb-tg" {
+  name     = "${var.name}-proxy"
+  port     = 9050
+  protocol = "TCP" //"HTTP"
+  vpc_id   = aws_vpc.main.id
+
+  health_check {
+    path                = "/"
+    healthy_threshold   = 3
+    unhealthy_threshold = 3
+    interval            = 30
+    protocol            = "HTTP"
+    port                = 8080
+  }
+}
+
+resource "aws_lb_listener" "proxy-lb-listener" {
+  load_balancer_arn = aws_lb.proxy-lb.arn
+  port              = "9050"
+  protocol          = "TCP" //"HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.proxy-lb-tg.arn
+  }
+}
+
+resource "aws_security_group" "proxy_instance" {
+  vpc_id      = aws_vpc.main.id
+  name_prefix = "proxy_instance"
+  description = "access to/from proxy instances"
+
+  ingress {
+    cidr_blocks = ["0.0.0.0/0", ]
+    description = "ssh"
+    protocol    = "tcp"
+    from_port   = 0
+    to_port     = 22
+  }
+
+  ingress {
+    cidr_blocks = [aws_vpc.main.cidr_block]
+    description = "socks5"
+    protocol    = "tcp"
+    from_port   = 0
+    to_port     = 9050
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group" "lb" {
+  name        = "${var.name}-proxy-lb-security-group"
+  description = "controls access to the proxy load balancer"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    protocol        = -1
+    from_port       = 0
+    to_port         = 0
+    security_groups = [aws_security_group.proxy_instance.id]
+  }
+}
+
+resource "aws_security_group_rule" "lb-egress" {
+  security_group_id        = aws_security_group.lb.id
+  type                     = "egress"
+  protocol                 = -1
+  from_port                = 0
+  to_port                  = 0
+  source_security_group_id = aws_security_group.proxy-target-group.id
+}
+
+resource "aws_security_group" "proxy-target-group" {
+  name        = "${var.name}-proxy-target-group"
+  description = "controls access to the proxy containers"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    protocol        = -1
+    from_port       = 0
+    to_port         = 0
+    security_groups = [aws_security_group.lb.id]
+  }
+
+  egress {
+    protocol        = -1
+    from_port       = 0
+    to_port         = 0
+    security_groups = [aws_security_group.lb.id]
+  }
+}
+
+resource "aws_launch_template" "proxy-instance-template" {
+  name                                 = "${var.name}-proxy"
+  image_id                             = data.aws_ami.latest_amazon_linux.id
+  instance_initiated_shutdown_behavior = "terminate"
+  instance_type                        = var.instance_type
+  instance_market_options {
+    market_type = "spot"
+  }
+  user_data = base64encode(<<EOF
+#!/bin/bash
+    yum update -y
+    amazon-linux-extras install epel -y
+    yum-config-manager --enable epel
+    yum install tor nc -y
+    echo "SOCKSPort 0.0.0.0:9050" >> /etc/tor/torrc
+    service tor start
+    chkconfig tor on
+    while true; do echo -e 'HTTP/1.1 200 OK\r\n' | nc -lp 8080 > /dev/null; echo Healthcheck >> /var/log/messages; done &
+    systemctl start crond
+    systemctl enable crond
+    cat << EOSC > /tmp/hup
+#!/bin/bash
+echo "Sending hup to tor processes"
+for pid in \$(pgrep tor); do /bin/kill -1 $pid ; done
+EOSC
+    chmod +x /tmp/hup
+    (crontab -l 2>/dev/null || true; echo "* * * * * /tmp/hup >> /var/log/messages") | crontab -
+EOF
+  )
+  iam_instance_profile {
+    name = aws_iam_instance_profile.instance_profile.name
+  }
+  vpc_security_group_ids = [aws_security_group.proxy_instance.id]
+  tag_specifications {
+    resource_type = "instance"
+    tags = {
+      Name = "db1000n-proxy"
+    }
+  }
+  tag_specifications {
+    resource_type = "volume"
+    tags = {
+      Name = "db1000n-proxy"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      Name = "db1000n-proxy"
+    }
+  }
+}
+
+resource "aws_autoscaling_group" "proxy" {
+  name                      = "${var.name}-proxy"
+  capacity_rebalance        = true
+  desired_capacity          = var.desired_capacity
+  max_size                  = var.max_size
+  min_size                  = var.min_size
+  vpc_zone_identifier       = [for subnet in aws_subnet.main : subnet.id]
+  health_check_grace_period = 180
+  target_group_arns         = [aws_lb_target_group.proxy-lb-tg.arn]
+  launch_template {
+    id      = aws_launch_template.proxy-instance-template.id
+    version = aws_launch_template.proxy-instance-template.latest_version
+  }
 }

--- a/terraform/aws/tor-proxy/tor-proxy.tf
+++ b/terraform/aws/tor-proxy/tor-proxy.tf
@@ -1,0 +1,202 @@
+variable "name" {}
+variable "private_subnet_ids" {}
+variable "public_subnet_ids" {}
+variable "vpc" {}
+variable "allow_ssh" {}
+variable "arch_ami" {}
+variable "instance_type" {}
+variable "extra_startup_script" {}
+variable "instance_profile" {}
+variable "desired_capacity" {}
+variable "min_size" {}
+variable "max_size" {}
+
+output "lb" {
+  value = aws_lb.proxy-lb
+}
+
+resource "aws_lb" "proxy-lb" {
+  name               = "${var.name}-proxy"
+  internal           = true
+  load_balancer_type = "network"
+  subnets            = var.private_subnet_ids
+}
+
+resource "aws_lb_target_group" "proxy-lb-tg" {
+  name     = "${var.name}-proxy"
+  port     = 9050
+  protocol = "TCP"
+  vpc_id   = var.vpc.id
+
+  health_check {
+    path                = "/"
+    healthy_threshold   = 3
+    unhealthy_threshold = 3
+    interval            = 30
+    protocol            = "HTTP"
+    port                = 8080
+  }
+}
+
+resource "aws_lb_listener" "proxy-lb-listener" {
+  load_balancer_arn = aws_lb.proxy-lb.arn
+  port              = "9050"
+  protocol          = "TCP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.proxy-lb-tg.arn
+  }
+}
+
+resource "aws_security_group" "proxy_instance" {
+  vpc_id      = var.vpc.id
+  name_prefix = "proxy_instance"
+  description = "access to/from proxy instances"
+
+  dynamic "ingress" {
+    for_each = var.allow_ssh ? ["ssh"] : []
+    content {
+      cidr_blocks = ["0.0.0.0/0", ]
+      description = "ssh"
+      protocol    = "tcp"
+      from_port   = 0
+      to_port     = 22
+    }
+  }
+
+  ingress {
+    cidr_blocks = [var.vpc.cidr_block]
+    description = "socks5"
+    protocol    = "tcp"
+    from_port   = 0
+    to_port     = 9050
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group" "lb" {
+  name        = "${var.name}-proxy-lb-security-group"
+  description = "controls access to the proxy load balancer"
+  vpc_id      = var.vpc.id
+
+  ingress {
+    protocol        = -1
+    from_port       = 0
+    to_port         = 0
+    security_groups = [aws_security_group.proxy_instance.id]
+  }
+}
+
+resource "aws_security_group_rule" "lb-egress" {
+  security_group_id        = aws_security_group.lb.id
+  type                     = "egress"
+  protocol                 = -1
+  from_port                = 0
+  to_port                  = 0
+  source_security_group_id = aws_security_group.proxy-target-group.id
+}
+
+resource "aws_security_group" "proxy-target-group" {
+  name        = "${var.name}-proxy-target-group"
+  description = "controls access to the proxy containers"
+  vpc_id      = var.vpc.id
+
+  ingress {
+    protocol        = -1
+    from_port       = 0
+    to_port         = 0
+    security_groups = [aws_security_group.lb.id]
+  }
+
+  egress {
+    protocol        = -1
+    from_port       = 0
+    to_port         = 0
+    security_groups = [aws_security_group.lb.id]
+  }
+}
+
+data "aws_ami" "latest_amazon_linux" {
+  owners      = ["amazon"]
+  most_recent = true
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-kernel-*-hvm-*-${var.arch_ami}-gp2"]
+  }
+}
+
+resource "aws_launch_template" "proxy-instance-template" {
+  name                                 = "${var.name}-proxy"
+  image_id                             = data.aws_ami.latest_amazon_linux.id
+  instance_initiated_shutdown_behavior = "terminate"
+  instance_type                        = var.instance_type
+  instance_market_options {
+    market_type = "spot"
+  }
+  user_data = base64encode(join("\n", [<<EOF
+#!/bin/bash
+    yum update -y
+    amazon-linux-extras install epel -y
+    yum-config-manager --enable epel
+    yum install tor nc -y
+    echo "SOCKSPort 0.0.0.0:9050" >> /etc/tor/torrc
+    service tor start
+    chkconfig tor on
+    while true; do echo -e 'HTTP/1.1 200 OK\r\n' | nc -lp 8080 > /dev/null; echo Healthcheck >> /var/log/messages; done &
+    systemctl start crond
+    systemctl enable crond
+    cat << EOSC > /tmp/hup
+#!/bin/bash
+echo "Sending hup to tor processes"
+for pid in \$(pgrep tor); do /bin/kill -1 \$pid ; done
+EOSC
+    chmod +x /tmp/hup
+    (crontab -l 2>/dev/null || true; echo "* * * * * /tmp/hup >> /var/log/messages") | crontab -
+EOF
+    , var.extra_startup_script
+  ]))
+  iam_instance_profile {
+    name = var.instance_profile.name
+  }
+  vpc_security_group_ids = [aws_security_group.proxy_instance.id]
+  tag_specifications {
+    resource_type = "instance"
+    tags = {
+      Name = "db1000n-proxy"
+    }
+  }
+  tag_specifications {
+    resource_type = "volume"
+    tags = {
+      Name = "db1000n-proxy"
+    }
+  }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags = {
+      Name = "db1000n-proxy"
+    }
+  }
+}
+
+resource "aws_autoscaling_group" "proxy" {
+  name                      = "${var.name}-proxy"
+  capacity_rebalance        = true
+  desired_capacity          = var.desired_capacity
+  max_size                  = var.max_size
+  min_size                  = var.min_size
+  vpc_zone_identifier       = var.public_subnet_ids
+  health_check_grace_period = 180
+  target_group_arns         = [aws_lb_target_group.proxy-lb-tg.arn]
+  launch_template {
+    id      = aws_launch_template.proxy-instance-template.id
+    version = aws_launch_template.proxy-instance-template.latest_version
+  }
+}

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -45,3 +45,34 @@ variable "zones" {
   description = "number of availability zones"
   default     = 2
 }
+
+# if you have multiple aws accounts you are managing with
+# terraform eg with aws-vault, specify your auth profile here.
+# leave null to use default profile
+variable "profile" {
+  type        = string
+  description = "aws auth profile"
+  default     = null
+}
+
+variable "allow_ssh" {
+  type        = bool
+  description = "allow port 22 access to proxy and db1000n instances"
+  default     = true
+}
+
+# Optional. I use this to set ec2-user's password, enabling serial port
+# access to ec2 instances via the AWS console, even for instances in private
+# networks. IMHO this is more secure than exposing port 22 to the outside world
+# example: "usermod --password <encrypted password> ec2-user"
+variable "extra_startup_script" {
+  type        = string
+  description = "commands to append to instance startup script"
+  default     = ""
+}
+
+variable "enable_tor_proxy" {
+  type        = bool
+  description = "create tor proxy for outbound connections"
+  default     = false
+}

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -39,3 +39,9 @@ variable "desired_capacity" {
   description = "number of instances to run"
   default     = 30
 }
+
+variable "zones" {
+  type        = number
+  description = "number of availability zones"
+  default     = 2
+}


### PR DESCRIPTION
# Description

This is more a basis for discussion than a serious proposal to merge. I'm happy to take suggestions, I am not a tor expert so there may be much that can be improved, eg using some other existing tor proxy setup, or not using one at all. 

The goal is to obfuscate the origin IPs and keep them changing, and to create a simple way of creating a db1000n installation with proxy, in AWS. It's immediate benefit is that it seems to work, as far as I can tell.

Notes:
- var.name is changed as NLBs don't support underscores in their names
- the db1000n servers will need to be restarted if the NLB is recreated. Is it possible to change the db1000n proxy config without restarting?
- there is a var.zones variable that allows you to configure the number of availability zones - defaults to 2. LBs require >1
- the tor instances have a netcat-based healthcheck. There's probably a better way
- the tor instances have a cron job that calls HUP on tor processes every min, to get a new IP
- works with the newly defaulted arm instances

### Update after discussion with @Arriven 

The proxy is now optional, configured using the boolean `var.enable_tor_proxy`. This defaults to false, as with all the related functionality I have added. Doing `terraform apply` with an earlier tfvars file will get the same results as previously, with the exception that the subnets are arranged slightly differently (with 2 availability zones).

You can switch the enable_tor_proxy setting on existing infrastructure, but the db1000n instances will need to be restarted as the db1000n docker invocation is different and the instances won't automatically restart.

I have changed the type of change to 'non breaking', as doing applying the new code from nothing will produce the same results as before. But running `apply` on existing infrastructure will change a few things, so I recommend `destroy` then `apply`.

Final note: I have made world port 22 visibility optional, as I personally prefer to go in via the EC2 serial connection in the console, which works for instances both public and private subnets, and I am a bit uncomfortable exposing any port to the outside world I don't have to. By default, port 22 is world visible, as before.

## Type of change

Please delete options that are not relevant.

- [ x] Non-breaking change (new functionality added but default behaviour is as-before)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

tests were carried out with the ireland variable file

- [x] Test A: apply/delete/apply - no problems with creating or deleting
- [x] Test B: 24hr soak test in eu workspace
- [x] Test C: apply + enable/disable the proxy

## Test Configuration

- Release version: git hash 1df67b9 (make funlen a little happier)
- Platform: default

## Logs

```text
docker logs <container> | grep Response
 [ Response rate ]  0.0%
 [ Response rate ]  9.1%
 [ Response rate ] 14.3%
 [ Response rate ] 27.5%
 [ Response rate ] 41.7%
 [ Response rate ] 42.9%
 [ Response rate ] 47.3%
 [ Response rate ] 42.1%
 [ Response rate ] 44.0%
 [ Response rate ] 46.8%
 [ Response rate ] 49.7%
 [ Response rate ] 49.6%
 [ Response rate ] 53.3%
 [ Response rate ] 52.8%
 [ Response rate ] 53.1%
 [ Response rate ] 51.8%
 [ Response rate ] 56.0%
 [ Response rate ] 54.0%
 [ Response rate ] 54.3%
 [ Response rate ] 51.8%
 [ Response rate ] 52.9%
 [ Response rate ] 51.3%
 [ Response rate ] 51.9%
 [ Response rate ] 54.7%
 [ Response rate ] 53.6%
 [ Response rate ] 53.7%
...
```

## Screenshots

<img width="848" alt="Screenshot 2022-03-24 at 12 26 52" src="https://user-images.githubusercontent.com/1754942/159916587-b65b85a8-1e76-428d-b1df-74c716364fa2.png">

