### PR TITLE
Руський - це український. Варто про це пам'ятати.

### DIFF
--- a/src/runner/runner.go
+++ b/src/runner/runner.go
@@ -217,7 +217,7 @@ func dumpMetrics(clientID string) error {
 	networkStatsWriter := tabwriter.NewWriter(os.Stdout, 1, 1, 1, ' ', tabwriter.AlignRight)
 
 	if bytesGenerated > 0 {
-		fmt.Fprintln(networkStatsWriter, "\n\n!Атака проводиться успішно! Руський воєнний корабль іди нахуй!")
+		fmt.Fprintln(networkStatsWriter, "\n\n!Атака проводиться успішно! Русскій воєнний корабль іди нахуй!")
 		fmt.Fprintln(networkStatsWriter, "!Attack is successful! Russian warship, go fuck yourself!")
 
 		const BytesInMegabytes = 1024 * 1024


### PR DESCRIPTION
Ру́ський (прикметник) (давньоруськ. руськии, пол. ruski) — в українській мові такий, що відноситься до часів Русі або до її населення — русічи їхніх нащадків — українців. Слово руський не слід плутати з рос. русский, тобто росіянин.
