### PR TITLE
Update Azure terraform config

### DIFF
--- a/terraform/azure/README.md
+++ b/terraform/azure/README.md
@@ -11,10 +11,11 @@
 
 The composition creates container instances in 6 different regions for a broader attack. If you want to make a different setup, just alter modules in the `main.tf`.
 
-Create a new `terraform.tfvars` file in the folder, if you want to change the default configuration of the farm:
+Create a new `terraform.tfvars` file in the folder, if you want to change the default configuration of the farm (`db1000n` can be configured with either command line parameters or environment variables, former having precedence over the latter):
 
 - `bomblet_count=10` - can be used for custom number of containers per region
-- `attack_commands=["/usr/src/app/main","-c=https://link_to_your_config_file"]`
+- `attack_commands=["/usr/src/app/db1000n","-c=https://link_to_your_config_file"]`
+- `attack_environment_variables={"ENABLE_PRIMITIVE":"false"}`
 
 `terraform init` - to restore all dependencies.
 

--- a/terraform/azure/bomblet/variables.tf
+++ b/terraform/azure/bomblet/variables.tf
@@ -23,5 +23,5 @@ variable "attack_environment_variables" {
 }
 
 variable "attack_commands" {
-  default = ["/usr/src/app/main", "-c=https://raw.githubusercontent.com/db1000n-coordinators/LoadTestConfig/main/config.json"]
+  default = null
 }

--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -10,59 +10,65 @@ resource "azurerm_resource_group" "main" {
 module "bomblet" {
   source = "./bomblet"
 
-  bomblet_count       = var.bomblet_count
-  region              = "northeurope"
-  prefix              = var.prefix
-  resource_group_name = azurerm_resource_group.main.name
-  attack_commands     = var.attack_commands
+  bomblet_count                = var.bomblet_count
+  region                       = "northeurope"
+  prefix                       = var.prefix
+  resource_group_name          = azurerm_resource_group.main.name
+  attack_commands              = var.attack_commands
+  attack_environment_variables = var.attack_environment_variables
 }
 
 module "bomblet_we" {
   source = "./bomblet"
 
-  bomblet_count       = var.bomblet_count
-  region              = "westeurope"
-  prefix              = var.prefix
-  resource_group_name = azurerm_resource_group.main.name
-  attack_commands     = var.attack_commands
+  bomblet_count                = var.bomblet_count
+  region                       = "westeurope"
+  prefix                       = var.prefix
+  resource_group_name          = azurerm_resource_group.main.name
+  attack_commands              = var.attack_commands
+  attack_environment_variables = var.attack_environment_variables
 }
 
 module "bomblet_cc" {
   source = "./bomblet"
 
-  bomblet_count       = var.bomblet_count
-  region              = "canadacentral"
-  prefix              = var.prefix
-  resource_group_name = azurerm_resource_group.main.name
-  attack_commands     = var.attack_commands
+  bomblet_count                = var.bomblet_count
+  region                       = "canadacentral"
+  prefix                       = var.prefix
+  resource_group_name          = azurerm_resource_group.main.name
+  attack_commands              = var.attack_commands
+  attack_environment_variables = var.attack_environment_variables
 }
 
 module "bomblet_uae" {
   source = "./bomblet"
 
-  bomblet_count       = var.bomblet_count
-  region              = "uaenorth"
-  prefix              = var.prefix
-  resource_group_name = azurerm_resource_group.main.name
-  attack_commands     = var.attack_commands
+  bomblet_count                = var.bomblet_count
+  region                       = "uaenorth"
+  prefix                       = var.prefix
+  resource_group_name          = azurerm_resource_group.main.name
+  attack_commands              = var.attack_commands
+  attack_environment_variables = var.attack_environment_variables
 }
 
 module "bomblet_cu" {
   source = "./bomblet"
 
-  bomblet_count       = var.bomblet_count
-  region              = "centralus"
-  prefix              = var.prefix
-  resource_group_name = azurerm_resource_group.main.name
-  attack_commands     = var.attack_commands
+  bomblet_count                = var.bomblet_count
+  region                       = "centralus"
+  prefix                       = var.prefix
+  resource_group_name          = azurerm_resource_group.main.name
+  attack_commands              = var.attack_commands
+  attack_environment_variables = var.attack_environment_variables
 }
 
 module "bomblet_ea" {
   source = "./bomblet"
 
-  bomblet_count       = var.bomblet_count
-  region              = "eastasia"
-  prefix              = var.prefix
-  resource_group_name = azurerm_resource_group.main.name
-  attack_commands     = var.attack_commands
+  bomblet_count                = var.bomblet_count
+  region                       = "eastasia"
+  prefix                       = var.prefix
+  resource_group_name          = azurerm_resource_group.main.name
+  attack_commands              = var.attack_commands
+  attack_environment_variables = var.attack_environment_variables
 }

--- a/terraform/azure/variables.tf
+++ b/terraform/azure/variables.tf
@@ -10,6 +10,11 @@ variable "prefix" {
 }
 
 variable "attack_commands" {
-  default     = ["/usr/src/app/db1000n", "-c=https://raw.githubusercontent.com/db1000n-coordinators/LoadTestConfig/main/config.json"]
+  default     = null
   description = "The command to execute an attack with support of specifying additional flags."
+}
+
+variable "attack_environment_variables" {
+  default     = { "ENABLE_PRIMITIVE" : "false" }
+  description = "Environment variables for the container."
 }


### PR DESCRIPTION
# Description

Update the terraform config for Azure:
- stop overriding container's `commands` (the default config URL was wrong);
- propagate `environment_variables` and set ``ENABLE_PRIMITIVE: false``.

Fixes # (issue)
Now terraform deployment for Azure can be launched right away without the need of configuration update, and disables primitive jobs by default (complementing https://github.com/Arriven/db1000n/pull/428)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

To test `ENABLE_PRIMITIVE=false`:
- [x] Test A: run `terraform apply` with the corrected config but without the environment variable setting: the number of jobs launched for 195.189.222.1:53 is 44 (as per current config: 22 TCP+22 UDP)
- [x] Test B: run `terraform apply` with the corrected config and with the environment variable setting (as in the PR): the number of jobs launched for 195.189.222.1:53 is 22 (as per current config: 22 TCP only) + "There is a filter defined for a job but this client doesn't pass it - skip the job" message in the logs.

## Test Configuration

- Release version: 0.8.4
- Platform: Azure container instances

## Screenshots

![azure](https://user-images.githubusercontent.com/24360626/160183733-31f20581-5800-4d66-8c19-df167217760a.png)
