### PR TITLE
Fix updater exiting early

### DIFF
--- a/src/runner/config/updater.go
+++ b/src/runner/config/updater.go
@@ -24,9 +24,9 @@ func UpdateLocal(destinationPath string, configPaths []string, backupConfig []by
 		if rawConfig := FetchRawConfig(configPaths, lastKnownConfig); !bytes.Equal(lastKnownConfig.Body, rawConfig.Body) {
 			if err := writeConfig(rawConfig.Body, destinationPath); err != nil {
 				log.Printf("Error writing config: %v", err)
-			}
 
-			return
+				return
+			}
 		}
 
 		time.Sleep(1 * time.Minute)


### PR DESCRIPTION
# Description

https://github.com/Arriven/db1000n/commit/750f6bdf27af85a19427cc0bf63d0e23b157a384#diff-010176c2ca9e3ceeacb9d76da1fca2f2df823fd20df0bb68d2a773616e063de5 introduced a bug in updater where it will exit upon successful file download. Previously it would only exit if there's an issue while trying to download the file.

It's easy to verify even without using Docker by running `go run main.go --updater-mode=true` on v0.8.6

Fixes https://github.com/Arriven/db1000n/issues/439

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)