### PR TITLE
neutral name for terraform azure

### DIFF
--- a/terraform/azure/variables.tf
+++ b/terraform/azure/variables.tf
@@ -5,7 +5,7 @@ variable "bomblet_count" {
 }
 
 variable "prefix" {
-  default     = "attack"
+  default     = "main"
   description = "The default prefix for resources."
 }
 


### PR DESCRIPTION
# Description

Make azure terraform names more neutral to avoid banning

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Test Configuration

- Release version:
- Platform:

## Logs

```text
logs
```

## Screenshots

- [x] No screenshot
