### PR TITLE
Update StartDB1000N.bat

### DIFF
--- a/scripts/StartDB1000N.bat
+++ b/scripts/StartDB1000N.bat
@@ -16,7 +16,7 @@ rem Iterate over list of all files in release
 echo Foreach ($Asset IN $Assets)                                                  >> %temp%\GetDB1000N.ps1
 echo {                                                                            >> %temp%\GetDB1000N.ps1
 rem Search for windows x64 build with regex
-echo 	if ($Asset.name -match 'db1000n_.*_windows_amd64.zip')                    >> %temp%\GetDB1000N.ps1
+echo 	if ($Asset.name -match 'db1000n_windows_amd64.zip')                    >> %temp%\GetDB1000N.ps1
 echo 	{                                                                         >> %temp%\GetDB1000N.ps1
 rem Download found build
 echo 		$DownloadURL = $Asset.browser_download_url                            >> %temp%\GetDB1000N.ps1


### PR DESCRIPTION
Change "$Asset.name -match" as file name to download for windows is "db1000n_windows_amd64.zip"

# Description

Without that change, file is not downloaded as previous regexp doesn't match Asset-name

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Change the script directly on my PC and runed it. Works fine, zip file downloaded and extracted 

## Test Configuration

- Release version:
- Platform:

## Logs

```text
logs
```

## Screenshots

- [ ] No screenshot
