### PR TITLE
Update StartDB1000N.bat

### DIFF
--- a/scripts/StartDB1000N.bat
+++ b/scripts/StartDB1000N.bat
@@ -3,7 +3,7 @@ rem Parsing command line argument to get target download folder
 echo $SaveFolder = $args[0]                                                       >  %temp%\GetDB1000N.ps1
 echo if ($args.count -lt 1)                                                       >> %temp%\GetDB1000N.ps1
 echo {                                                                            >> %temp%\GetDB1000N.ps1
-echo 	Write-Host "Missing save folder parameter"                                  >> %temp%\GetDB1000N.ps1
+echo 	Write-Host "Missing save folder parameter"                                >> %temp%\GetDB1000N.ps1
 echo }                                                                            >> %temp%\GetDB1000N.ps1
 rem Create target folder if it don't exist yet
 echo New-Item -ItemType Directory -Force -Path $SaveFolder                        >> %temp%\GetDB1000N.ps1

--- a/scripts/StartDB1000N.bat
+++ b/scripts/StartDB1000N.bat
@@ -3,21 +3,21 @@ rem Parsing command line argument to get target download folder
 echo $SaveFolder = $args[0]                                                       >  %temp%\GetDB1000N.ps1
 echo if ($args.count -lt 1)                                                       >> %temp%\GetDB1000N.ps1
 echo {                                                                            >> %temp%\GetDB1000N.ps1
-echo 	Write-Host "Missing save folder parameter"                                >> %temp%\GetDB1000N.ps1
+echo 	Write-Host "Missing save folder parameter"                                  >> %temp%\GetDB1000N.ps1
 echo }                                                                            >> %temp%\GetDB1000N.ps1
 rem Create target folder if it don't exist yet
 echo New-Item -ItemType Directory -Force -Path $SaveFolder                        >> %temp%\GetDB1000N.ps1
 rem Getting list of files in latest release via github API and parse response JSON
 echo $JSONURL = "https://api.github.com/repos/Arriven/db1000n/releases/latest"    >> %temp%\GetDB1000N.ps1
-echo $JSON = Invoke-WebRequest -Uri $JSONURL                                      >> %temp%\GetDB1000N.ps1
+echo $JSON = Invoke-WebRequest -Uri $JSONURL -UseBasicParsing                     >> %temp%\GetDB1000N.ps1
 echo $ParsedJSON = ConvertFrom-Json -InputObject $JSON                            >> %temp%\GetDB1000N.ps1
 echo $Assets = Select-Object -InputObject $ParsedJSON -ExpandProperty assets      >> %temp%\GetDB1000N.ps1
 rem Iterate over list of all files in release
 echo Foreach ($Asset IN $Assets)                                                  >> %temp%\GetDB1000N.ps1
 echo {                                                                            >> %temp%\GetDB1000N.ps1
 rem Search for windows x64 build with regex
-echo 	if ($Asset.name -match 'db1000n_windows_amd64.zip')                    >> %temp%\GetDB1000N.ps1
-echo 	{                                                                         >> %temp%\GetDB1000N.ps1
+echo 	if ($Asset.name -match 'db1000n_windows_amd64.zip')                         >> %temp%\GetDB1000N.ps1
+echo 	{                                                                           >> %temp%\GetDB1000N.ps1
 rem Download found build
 echo 		$DownloadURL = $Asset.browser_download_url                            >> %temp%\GetDB1000N.ps1
 echo 		$ZIPPath = Join-Path -Path $SaveFolder -ChildPath "db1000n.zip"       >> %temp%\GetDB1000N.ps1


### PR DESCRIPTION
Add -UseBasicParsing in Invoke-WebRequest to avoid this error message :

"The response content cannot be parsed because the Internet Explorer engine is not available, or Internet Explorer's first-launch configuration is not complete. Specify the UseBasicParsing parameter and try again."

# Description

Add -UseBasicParsing in Invoke-WebRequest to avoid this error message :

"The response content cannot be parsed because the Internet Explorer engine is not available, or Internet Explorer's first-launch configuration is not complete. Specify the UseBasicParsing parameter and try again."

Fixes # (issue)

"The response content cannot be parsed because the Internet Explorer engine is not available, or Internet Explorer's first-launch configuration is not complete. Specify the UseBasicParsing parameter and try again."

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

startdb1000n.bat modified on my PC and runed after been saved. 

## Test Configuration

- Release version:
- Platform: Microsoft 10 Enterprise

## Logs

```text
logs
```

## Screenshots

- [ ] No screenshot
