### PR TITLE
Added aarch64 architecture

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -27,6 +27,7 @@ case "$OSARCH" in
   armv6l)   INSTALL_ARCH="arm" ;;
   armv7l)   INSTALL_ARCH="arm" ;;
   arm*)     INSTALL_ARCH="arm64" ;;
+  aarch64*) INSTALL_ARCH="arm64" ;;
   *)        echo "unknown: $OSARCH"; exit 1 ;;
 esac
 


### PR DESCRIPTION
For some devices (like PinePhone), OS_ARCH is aarch64, which is the same as arm64.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Test Configuration

- Release version:
- Platform:

## Logs

```text
logs
```

## Screenshots

- [ ] No screenshot
