### PR TITLE
Combine metrics summary into one object

### DIFF
--- a/src/utils/metrics/metrics.go
+++ b/src/utils/metrics/metrics.go
@@ -165,10 +165,10 @@ func (r *Reporter) SumAllStatsByTarget() PerTargetStats {
 // WriteSummary dumps Reporter contents into the target.
 func (r *Reporter) WriteSummary(logger *zap.Logger) {
 	stats := r.SumAllStatsByTarget()
+	statFields := make([]zap.Field, 0, len(stats)+1) // +1 for total stats
 
 	var totals Stats
 
-	statFields := make([]zap.Field, 0, len(stats)+1) // +1 for total stats
 	for _, tgt := range stats.sortedTargets() {
 		tgtStats := stats[tgt]
 		statFields = append(statFields, zap.Object(tgt, &tgtStats))
@@ -189,6 +189,7 @@ func (stats *Stats) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	enc.AddUint64("requests_sent", stats[RequestsSentStat])
 	enc.AddUint64("responses_received", stats[ResponsesReceivedStat])
 	enc.AddUint64("bytes_sent", stats[BytesSentStat])
+
 	return nil
 }
 


### PR DESCRIPTION
so the whole report goes as one log entry with a JSON object for each target

# Description

This might be helpful for logging and assessing to have the whole summary report as one entry. Though arguably it makes it even less readable in terminal's output, and I tried to improve that with pr #517. I tried to make `zap` pretty print this huge JSON report object (for the case when `-log-format simple` from #517), but it was way too complicated for such a simple feature. Though it might still be possible.

What do you guys think? Could this be helpful?

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Potentially somebody could rely on the current summary format, but with so many swift changes and the recent move to `zap` - I doubt it.

## How Has This Been Tested?

By running and looking at the output in a terminal.

## Test Configuration

- Release version: latest main branch (v0.8.30 is the latest current release)
- Platform: Mac OS

## Logs

Output sample (real values crossed out, truncated for shorter text)

```text
{"http://sample": {"requests_attempted": 7, "requests_sent": 0, "responses_received": 0, "bytes_sent": 0}, "http://XX.XX.XX.XX": {"requests_attempted": 7, "requests_sent": 0, "responses_received": 0, "bytes_sent": 0}, "http://sample": {"requests_attempted": 7, "requests_sent": 0, "responses_received": 0, "bytes_sent": 0}, "total": {"requests_attempted": 185664, "requests_sent": 183986, "responses_received": 138, "bytes_sent": 1862621}}
```
the full log entry with the current default format would look like this:
```text
{"level":"info","ts":1650809773.640194,"caller":"metrics/metrics.go:183","msg":"stats","http://sample":{"requests_attempted":3,"requests_sent":3,"responses_received":3,"bytes_sent":624},"http://sample":{"requests_attempted":1,"requests_sent":1,"responses_received":1,"bytes_sent":191},"http://sample":{"requests_attempted":1,"requests_sent":1,"responses_received":1,"bytes_sent":197},"tcp://XX.XXX.X.XX:XX":{"requests_attempted":91924,"requests_sent":91924,"responses_received":0,"bytes_sent":919240},"total":{"requests_attempted":184496,"requests_sent":183902,"responses_received":54,"bytes_sent":1848272}}
```
