### PR TITLE
Simple output improvements (also make simple output format default)

### DIFF
--- a/main.go
+++ b/main.go
@@ -102,14 +102,7 @@ func main() {
 
 	go cancelOnSignal(logger, cancel)
 
-	var reporter metrics.Reporter
-
-	if *logFormat == simpleLogFormat {
-		reporter = metrics.NewConsoleReporter(os.Stdout)
-	} else {
-		reporter = metrics.NewZapReporter(logger)
-	}
-
+	reporter := newReporter(*logFormat, logger)
 	job.NewRunner(runnerConfigOptions, jobsGlobalConfig, reporter).Run(ctx, logger)
 }
 
@@ -173,4 +166,12 @@ func cancelOnSignal(logger *zap.Logger, cancel context.CancelFunc) {
 	<-sigs
 	logger.Info("terminating")
 	cancel()
+}
+
+func newReporter(logFormat string, logger *zap.Logger) metrics.Reporter {
+	if logFormat == simpleLogFormat {
+		return metrics.NewConsoleReporter(os.Stdout)
+	}
+
+	return metrics.NewZapReporter(logger)
 }

--- a/src/job/http.go
+++ b/src/job/http.go
@@ -78,7 +78,7 @@ func singleRequestJob(ctx context.Context, args config.Args, globalConfig *Globa
 		return nil, err
 	}
 
-	requestSize, _ := req.WriteTo(metrics.NopWriter{})
+	requestSize, _ := req.WriteTo(nopWriter{})
 
 	if a != nil {
 		tgt := target(req.URI())
@@ -173,7 +173,7 @@ func fastHTTPJob(ctx context.Context, args config.Args, globalConfig *GlobalConf
 			continue
 		}
 
-		requestSize, _ := req.WriteTo(metrics.NopWriter{})
+		requestSize, _ := req.WriteTo(nopWriter{})
 
 		if a != nil {
 			tgt := target(req.URI())
@@ -229,3 +229,8 @@ func sendFastHTTPRequest(client http.Client, req *fasthttp.Request, resp *fastht
 
 	return nil
 }
+
+// nopWriter implements io.Writer interface to simply track how much data has to be serialized
+type nopWriter struct{}
+
+func (w nopWriter) Write(p []byte) (int, error) { return len(p), nil }

--- a/src/job/runner.go
+++ b/src/job/runner.go
@@ -65,13 +65,15 @@ func NewConfigOptionsWithFlags() *ConfigOptions {
 type Runner struct {
 	cfgOptions    *ConfigOptions
 	globalJobsCfg *GlobalConfig
+	reporter      metrics.Reporter
 }
 
 // NewRunner according to the config
-func NewRunner(cfgOptions *ConfigOptions, globalJobsCfg *GlobalConfig) *Runner {
+func NewRunner(cfgOptions *ConfigOptions, globalJobsCfg *GlobalConfig, reporter metrics.Reporter) *Runner {
 	return &Runner{
 		cfgOptions:    cfgOptions,
 		globalJobsCfg: globalJobsCfg,
+		reporter:      reporter,
 	}
 }
 
@@ -84,10 +86,7 @@ func (r *Runner) Run(ctx context.Context, logger *zap.Logger) {
 	defer refreshTimer.Stop()
 	metrics.IncClient()
 
-	var (
-		cancel   context.CancelFunc
-		reporter *metrics.Reporter
-	)
+	var cancel context.CancelFunc
 
 	for {
 		rawConfig := config.FetchRawMultiConfig(logger, strings.Split(r.cfgOptions.PathsCSV, ","),
@@ -105,14 +104,13 @@ func (r *Runner) Run(ctx context.Context, logger *zap.Logger) {
 				cancel()
 			}
 
+			r.reporter.ClearData() // clear info about previous targets
+
 			if rawConfig.Encrypted {
 				logger.Info("config is encrypted, disabling logs")
-
-				reporter = nil
-				cancel = r.runJobs(ctx, cfg, reporter, zap.NewNop())
+				cancel = r.runJobs(ctx, cfg, nil, zap.NewNop())
 			} else {
-				reporter = metrics.NewReporter(r.globalJobsCfg.ClientID)
-				cancel = r.runJobs(ctx, cfg, reporter, logger)
+				cancel = r.runJobs(ctx, cfg, r.reporter, logger)
 			}
 		} else {
 			logger.Info("the config has not changed. Keep calm and carry on!")
@@ -129,8 +127,8 @@ func (r *Runner) Run(ctx context.Context, logger *zap.Logger) {
 			return
 		}
 
-		if reporter != nil {
-			reportMetrics(reporter, r.globalJobsCfg.ClientID, logger)
+		if r.reporter != nil {
+			reportMetrics(r.reporter, r.globalJobsCfg.ClientID, logger)
 		}
 	}
 }
@@ -151,7 +149,7 @@ func nonNilConfigOrDefault(c, defaultConfig *config.RawMultiConfig) *config.RawM
 	return defaultConfig
 }
 
-func (r *Runner) runJobs(ctx context.Context, cfg *config.MultiConfig, reporter *metrics.Reporter, logger *zap.Logger) (cancel context.CancelFunc) {
+func (r *Runner) runJobs(ctx context.Context, cfg *config.MultiConfig, reporter metrics.Reporter, logger *zap.Logger) (cancel context.CancelFunc) {
 	ctx, cancel = context.WithCancel(ctx)
 
 	var jobInstancesCount int
@@ -206,8 +204,8 @@ func (r *Runner) runJobs(ctx context.Context, cfg *config.MultiConfig, reporter 
 	return cancel
 }
 
-func reportMetrics(reporter *metrics.Reporter, clientID string, logger *zap.Logger) {
-	reporter.WriteSummary(logger)
+func reportMetrics(reporter metrics.Reporter, clientID string, logger *zap.Logger) {
+	reporter.WriteSummary()
 
 	if err := metrics.ReportStatistics(int64(reporter.Sum(metrics.BytesSentStat)), clientID); err != nil {
 		logger.Debug("error reporting statistics", zap.Error(err))

--- a/src/job/runner.go
+++ b/src/job/runner.go
@@ -108,6 +108,7 @@ func (r *Runner) Run(ctx context.Context, logger *zap.Logger) {
 
 			if rawConfig.Encrypted {
 				logger.Info("config is encrypted, disabling logs")
+
 				cancel = r.runJobs(ctx, cfg, nil, zap.NewNop())
 			} else {
 				cancel = r.runJobs(ctx, cfg, r.reporter, logger)

--- a/src/job/runner.go
+++ b/src/job/runner.go
@@ -207,7 +207,7 @@ func (r *Runner) runJobs(ctx context.Context, cfg *config.MultiConfig, reporter 
 func reportMetrics(reporter metrics.Reporter, clientID string, logger *zap.Logger) {
 	reporter.WriteSummary()
 
-	if err := metrics.ReportStatistics(int64(reporter.Sum(metrics.BytesSentStat)), clientID); err != nil {
+	if err := metrics.ReportStatistics(int64(reporter.SumBytesSent()), clientID); err != nil {
 		logger.Debug("error reporting statistics", zap.Error(err))
 	}
 }

--- a/src/job/runner.go
+++ b/src/job/runner.go
@@ -87,6 +87,7 @@ func (r *Runner) Run(ctx context.Context, logger *zap.Logger) {
 	metrics.IncClient()
 
 	var cancel context.CancelFunc
+
 	var metric *metrics.Metrics
 
 	for {

--- a/src/utils/metrics/accumulator.go
+++ b/src/utils/metrics/accumulator.go
@@ -1,0 +1,56 @@
+package metrics
+
+// Accumulator for statistical metrics for use in a single job. Requires Flush()-ing to Reporter.
+// Not concurrency-safe.
+type Accumulator struct {
+	jobID   string
+	metrics [NumStats]map[string]uint64 // Array of metrics by Stat. Each metric is a map of uint64 values by target.
+
+	data *ReporterData
+}
+
+type dimensions struct {
+	jobID  string
+	target string
+}
+
+// Add n to the Accumulator Stat value. Returns self for chaining.
+func (a *Accumulator) Add(target string, s Stat, n uint64) *Accumulator {
+	a.metrics[s][target] += n
+
+	return a
+}
+
+// Inc increases Accumulator Stat value by 1. Returns self for chaining.
+func (a *Accumulator) Inc(target string, s Stat) *Accumulator { return a.Add(target, s, 1) }
+
+// Flush Accumulator contents to the Reporter.
+func (a *Accumulator) Flush() {
+	for stat := RequestsAttemptedStat; stat < NumStats; stat++ {
+		for target, value := range a.metrics[stat] {
+			a.data.metrics[stat].Store(dimensions{jobID: a.jobID, target: target}, value)
+		}
+	}
+}
+
+// Clone a new, blank metrics Accumulator with the same Reporter as the original.
+func (a *Accumulator) Clone(jobID string) *Accumulator {
+	if a == nil {
+		return nil
+	}
+
+	return newAccumulator(jobID, a.data)
+}
+
+func newAccumulator(jobID string, data *ReporterData) *Accumulator {
+	res := &Accumulator{
+		jobID: jobID,
+		data:  data,
+	}
+
+	for s := RequestsAttemptedStat; s < NumStats; s++ {
+		res.metrics[s] = make(map[string]uint64)
+	}
+
+	return res
+}

--- a/src/utils/metrics/metrics.go
+++ b/src/utils/metrics/metrics.go
@@ -23,78 +23,35 @@
 // Package metrics collects and reports job metrics.
 package metrics
 
-import (
-	"fmt"
-	"io"
-	"sort"
-	"sync"
-	"text/tabwriter"
+import "sync"
 
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
-)
-
-// Stat is the type of statistical metrics.
-type Stat int
-
-const (
-	RequestsAttemptedStat Stat = iota
-	RequestsSentStat
-	ResponsesReceivedStat
-	BytesSentStat
-
-	NumStats
-)
-
-// String representation of the Stat.
-func (s Stat) String() string {
-	return [...]string{
-		"requests attempted",
-		"requests sent",
-		"responses received",
-		"bytes sent",
-	}[s]
-}
-
-type dimensions struct {
-	jobID  string
-	target string
-}
-
-// Reporter gathers metrics across jobs and reports them.
-// Concurrency-safe.
-type Reporter interface {
-	WriteSummary()
-	Sum(s Stat) uint64
-	ClearData()
-	NewAccumulator(jobID string) *Accumulator
-}
-
-type ZapReporter struct {
-	data   ReporterData
-	logger *zap.Logger
-}
-
-type ConsoleReporter struct {
-	data   ReporterData
-	target io.Writer
-}
 type ReporterData struct {
 	metrics [NumStats]sync.Map // Array of metrics by Stat. Each metric is a map of uint64 values by dimensions.
 }
 
-// NewZapReporter creates a new Reporter using a zap logger.
-func NewZapReporter(logger *zap.Logger) Reporter {
-	return &ZapReporter{logger: logger}
+// Clears all targets and stats
+func (d *ReporterData) ClearData() {
+	d.metrics = [NumStats]sync.Map{}
 }
 
-// NewConsoleReporter creates a new Reporter which outputs straight to the console
-func NewConsoleReporter(target io.Writer) Reporter {
-	return &ConsoleReporter{target: target}
+// Calculates the whole sum of sent bytes
+func (d *ReporterData) SumBytesSent() uint64 {
+	return d.sum(BytesSentStat)
+}
+
+// Calculates all targets and total stats
+func (d *ReporterData) SumAllStats() (stats PerTargetStats, totals Stats) {
+	stats = d.sumAllStatsByTarget()
+
+	for s := RequestsAttemptedStat; s < NumStats; s++ {
+		totals[s] = d.sum(s)
+	}
+
+	return
 }
 
 // Sum returns a total sum of metric s.
-func (d *ReporterData) Sum(s Stat) uint64 {
+func (d *ReporterData) sum(s Stat) uint64 {
 	var res uint64
 
 	d.metrics[s].Range(func(_, v any) bool {
@@ -111,70 +68,7 @@ func (d *ReporterData) Sum(s Stat) uint64 {
 	return res
 }
 
-func (d *ReporterData) ClearData() {
-	d.metrics = [NumStats]sync.Map{}
-}
-
-func (r *ZapReporter) ClearData() {
-	r.data.ClearData()
-}
-
-func (r *ConsoleReporter) ClearData() {
-	r.data.ClearData()
-}
-
-func (r *ZapReporter) Sum(s Stat) uint64 {
-	return r.data.Sum(s)
-}
-
-func (r *ConsoleReporter) Sum(s Stat) uint64 {
-	return r.data.Sum(s)
-}
-
-type (
-	// Stats contains all metrics packed as an array.
-	Stats [NumStats]uint64
-	// MultiStats contains multiple Stats as a slice. Useful for collecting Stats from coroutines.
-	MultiStats []Stats
-	// PerTargetStats is a map of Stats per target.
-	PerTargetStats map[string]Stats
-)
-
-// Sum up all Stats into a total Stats record.
-func (s MultiStats) Sum() Stats {
-	var res Stats
-
-	for i := range s {
-		for j := RequestsAttemptedStat; j < NumStats; j++ {
-			res[j] += s[i][j]
-		}
-	}
-
-	return res
-}
-
-func (ts PerTargetStats) sum(s Stat) uint64 {
-	var res uint64
-
-	for _, v := range ts {
-		res += v[s]
-	}
-
-	return res
-}
-
-func (ts PerTargetStats) sortedTargets() []string {
-	res := make([]string, 0, len(ts))
-	for k := range ts {
-		res = append(res, k)
-	}
-
-	sort.Strings(res)
-
-	return res
-}
-
-// SumAllStatsByTarget returns a total sum of all metrics by target.
+// Returns a total sum of all metrics by target.
 func (d *ReporterData) sumAllStatsByTarget() PerTargetStats {
 	res := make(PerTargetStats)
 
@@ -200,152 +94,3 @@ func (d *ReporterData) sumAllStatsByTarget() PerTargetStats {
 
 	return res
 }
-
-func (d *ReporterData) SumAllStats() (stats PerTargetStats, totals Stats) {
-	stats = d.sumAllStatsByTarget()
-
-	for s := RequestsAttemptedStat; s < NumStats; s++ {
-		totals[s] = d.Sum(s)
-	}
-
-	return
-}
-
-// WriteSummary dumps Reporter contents into the target.
-func (r *ZapReporter) WriteSummary() {
-	stats, totals := r.data.SumAllStats()
-
-	r.logger.Info("stats", zap.Object("total", &totals), zap.Object("targets", stats))
-}
-
-// MarshalLogObject is required to log PerTargetStats objects to zap above
-func (ts PerTargetStats) MarshalLogObject(enc zapcore.ObjectEncoder) error {
-	for _, tgt := range ts.sortedTargets() {
-		tgtStats := ts[tgt]
-
-		if err := enc.AddObject(tgt, &tgtStats); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// MarshalLogObject is required to log Stats objects to zap above
-func (stats *Stats) MarshalLogObject(enc zapcore.ObjectEncoder) error {
-	enc.AddUint64("requests_attempted", stats[RequestsAttemptedStat])
-	enc.AddUint64("requests_sent", stats[RequestsSentStat])
-	enc.AddUint64("responses_received", stats[ResponsesReceivedStat])
-	enc.AddUint64("bytes_sent", stats[BytesSentStat])
-
-	return nil
-}
-
-func (r *ConsoleReporter) WriteSummary() {
-	w := tabwriter.NewWriter(r.target, 1, 1, 1, ' ', tabwriter.AlignRight)
-
-	defer w.Flush()
-
-	stats, totals := r.data.SumAllStats()
-
-	fmt.Fprintln(w, "\n --- Traffic stats ---")
-	fmt.Fprintf(w, "|\tTarget\t|\tRequests attempted\t|\tRequests sent\t|\tResponses received\t|\tData sent \t|\n")
-
-	const BytesInMegabyte = 1024 * 1024
-
-	for _, tgt := range stats.sortedTargets() {
-		tgtStats := stats[tgt]
-
-		fmt.Fprintf(w, "|\t%s\t|\t%d\t|\t%d\t|\t%d\t|\t%.2f MB \t|\n", tgt,
-			tgtStats[RequestsAttemptedStat],
-			tgtStats[RequestsSentStat],
-			tgtStats[ResponsesReceivedStat],
-			float64(tgtStats[BytesSentStat])/BytesInMegabyte,
-		)
-
-		for s := range totals {
-			totals[s] += tgtStats[s]
-		}
-	}
-
-	fmt.Fprintln(w, "|\t---\t|\t---\t|\t---\t|\t---\t|\t--- \t|")
-	fmt.Fprintf(w, "|\tTotal\t|\t%d\t|\t%d\t|\t%d\t|\t%.2f MB \t|\n\n",
-		totals[RequestsAttemptedStat],
-		totals[RequestsSentStat],
-		totals[ResponsesReceivedStat],
-		float64(totals[BytesSentStat])/BytesInMegabyte,
-	)
-}
-
-// NewAccumulator returns a new metrics Accumulator for the Reporter.
-
-func (r *ZapReporter) NewAccumulator(jobID string) *Accumulator {
-	if r == nil {
-		return nil
-	}
-
-	return newAccumulator(jobID, &r.data)
-}
-
-func (r *ConsoleReporter) NewAccumulator(jobID string) *Accumulator {
-	if r == nil {
-		return nil
-	}
-
-	return newAccumulator(jobID, &r.data)
-}
-
-// Accumulator for statistical metrics for use in a single job. Requires Flush()-ing to Reporter.
-// Not concurrency-safe.
-type Accumulator struct {
-	jobID   string
-	metrics [NumStats]map[string]uint64 // Array of metrics by Stat. Each metric is a map of uint64 values by target.
-
-	data *ReporterData
-}
-
-// Add n to the Accumulator Stat value. Returns self for chaining.
-func (a *Accumulator) Add(target string, s Stat, n uint64) *Accumulator {
-	a.metrics[s][target] += n
-
-	return a
-}
-
-// Inc increases Accumulator Stat value by 1. Returns self for chaining.
-func (a *Accumulator) Inc(target string, s Stat) *Accumulator { return a.Add(target, s, 1) }
-
-// Flush Accumulator contents to the Reporter.
-func (a *Accumulator) Flush() {
-	for stat := RequestsAttemptedStat; stat < NumStats; stat++ {
-		for target, value := range a.metrics[stat] {
-			a.data.metrics[stat].Store(dimensions{jobID: a.jobID, target: target}, value)
-		}
-	}
-}
-
-// Clone a new, blank metrics Accumulator with the same Reporter as the original.
-func (a *Accumulator) Clone(jobID string) *Accumulator {
-	if a == nil {
-		return nil
-	}
-
-	return newAccumulator(jobID, a.data)
-}
-
-func newAccumulator(jobID string, data *ReporterData) *Accumulator {
-	res := &Accumulator{
-		jobID: jobID,
-		data:  data,
-	}
-
-	for s := RequestsAttemptedStat; s < NumStats; s++ {
-		res.metrics[s] = make(map[string]uint64)
-	}
-
-	return res
-}
-
-// NopWriter implements io.Writer interface to simply track how much data has to be serialized
-type NopWriter struct{}
-
-func (w NopWriter) Write(p []byte) (int, error) { return len(p), nil }

--- a/src/utils/metrics/reporter.go
+++ b/src/utils/metrics/reporter.go
@@ -1,0 +1,120 @@
+package metrics
+
+import (
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"go.uber.org/zap"
+)
+
+// Reporter gathers metrics across jobs and reports them.
+// Concurrency-safe.
+type Reporter interface {
+	// WriteSummary dumps Reporter contents into the target.
+	WriteSummary()
+
+	SumBytesSent() uint64
+	ClearData()
+
+	// NewAccumulator returns a new metrics Accumulator for the Reporter.
+	NewAccumulator(jobID string) *Accumulator
+}
+
+// ZapReporter
+
+type ZapReporter struct {
+	data   ReporterData
+	logger *zap.Logger
+}
+
+// NewZapReporter creates a new Reporter using a zap logger.
+func NewZapReporter(logger *zap.Logger) Reporter {
+	return &ZapReporter{logger: logger}
+}
+
+func (r *ZapReporter) WriteSummary() {
+	stats, totals := r.data.SumAllStats()
+
+	r.logger.Info("stats", zap.Object("total", &totals), zap.Object("targets", stats))
+}
+
+func (r *ZapReporter) NewAccumulator(jobID string) *Accumulator {
+	if r == nil {
+		return nil
+	}
+
+	return newAccumulator(jobID, &r.data)
+}
+
+func (r *ZapReporter) ClearData() {
+	r.data.ClearData()
+}
+
+func (r *ZapReporter) SumBytesSent() uint64 {
+	return r.data.SumBytesSent()
+}
+
+// ConsoleReporter
+
+type ConsoleReporter struct {
+	data   ReporterData
+	target io.Writer
+}
+
+// NewConsoleReporter creates a new Reporter which outputs straight to the console
+func NewConsoleReporter(target io.Writer) Reporter {
+	return &ConsoleReporter{target: target}
+}
+
+func (r *ConsoleReporter) WriteSummary() {
+	w := tabwriter.NewWriter(r.target, 1, 1, 1, ' ', tabwriter.AlignRight)
+
+	defer w.Flush()
+
+	stats, totals := r.data.SumAllStats()
+
+	fmt.Fprintln(w, "\n --- Traffic stats ---")
+	fmt.Fprintf(w, "|\tTarget\t|\tRequests attempted\t|\tRequests sent\t|\tResponses received\t|\tData sent \t|\n")
+
+	const BytesInMegabyte = 1024 * 1024
+
+	for _, tgt := range stats.sortedTargets() {
+		tgtStats := stats[tgt]
+
+		fmt.Fprintf(w, "|\t%s\t|\t%d\t|\t%d\t|\t%d\t|\t%.2f MB \t|\n", tgt,
+			tgtStats[RequestsAttemptedStat],
+			tgtStats[RequestsSentStat],
+			tgtStats[ResponsesReceivedStat],
+			float64(tgtStats[BytesSentStat])/BytesInMegabyte,
+		)
+
+		for s := range totals {
+			totals[s] += tgtStats[s]
+		}
+	}
+
+	fmt.Fprintln(w, "|\t---\t|\t---\t|\t---\t|\t---\t|\t--- \t|")
+	fmt.Fprintf(w, "|\tTotal\t|\t%d\t|\t%d\t|\t%d\t|\t%.2f MB \t|\n\n",
+		totals[RequestsAttemptedStat],
+		totals[RequestsSentStat],
+		totals[ResponsesReceivedStat],
+		float64(totals[BytesSentStat])/BytesInMegabyte,
+	)
+}
+
+func (r *ConsoleReporter) NewAccumulator(jobID string) *Accumulator {
+	if r == nil {
+		return nil
+	}
+
+	return newAccumulator(jobID, &r.data)
+}
+
+func (r *ConsoleReporter) ClearData() {
+	r.data.ClearData()
+}
+
+func (r *ConsoleReporter) SumBytesSent() uint64 {
+	return r.data.SumBytesSent()
+}

--- a/src/utils/metrics/reporter.go
+++ b/src/utils/metrics/reporter.go
@@ -12,19 +12,12 @@ import (
 // Concurrency-safe.
 type Reporter interface {
 	// WriteSummary dumps Reporter contents into the target.
-	WriteSummary()
-
-	SumBytesSent() uint64
-	ClearData()
-
-	// NewAccumulator returns a new metrics Accumulator for the Reporter.
-	NewAccumulator(jobID string) *Accumulator
+	WriteSummary(*Metrics)
 }
 
 // ZapReporter
 
 type ZapReporter struct {
-	data   ReporterData
 	logger *zap.Logger
 }
 
@@ -33,32 +26,15 @@ func NewZapReporter(logger *zap.Logger) Reporter {
 	return &ZapReporter{logger: logger}
 }
 
-func (r *ZapReporter) WriteSummary() {
-	stats, totals := r.data.SumAllStats()
+func (r *ZapReporter) WriteSummary(metrics *Metrics) {
+	stats, totals := metrics.SumAllStats()
 
 	r.logger.Info("stats", zap.Object("total", &totals), zap.Object("targets", stats))
-}
-
-func (r *ZapReporter) NewAccumulator(jobID string) *Accumulator {
-	if r == nil {
-		return nil
-	}
-
-	return newAccumulator(jobID, &r.data)
-}
-
-func (r *ZapReporter) ClearData() {
-	r.data.ClearData()
-}
-
-func (r *ZapReporter) SumBytesSent() uint64 {
-	return r.data.SumBytesSent()
 }
 
 // ConsoleReporter
 
 type ConsoleReporter struct {
-	data   ReporterData
 	target io.Writer
 }
 
@@ -67,12 +43,12 @@ func NewConsoleReporter(target io.Writer) Reporter {
 	return &ConsoleReporter{target: target}
 }
 
-func (r *ConsoleReporter) WriteSummary() {
+func (r *ConsoleReporter) WriteSummary(metrics *Metrics) {
 	w := tabwriter.NewWriter(r.target, 1, 1, 1, ' ', tabwriter.AlignRight)
 
 	defer w.Flush()
 
-	stats, totals := r.data.SumAllStats()
+	stats, totals := metrics.SumAllStats()
 
 	fmt.Fprintln(w, "\n --- Traffic stats ---")
 	fmt.Fprintf(w, "|\tTarget\t|\tRequests attempted\t|\tRequests sent\t|\tResponses received\t|\tData sent \t|\n")
@@ -101,20 +77,4 @@ func (r *ConsoleReporter) WriteSummary() {
 		totals[ResponsesReceivedStat],
 		float64(totals[BytesSentStat])/BytesInMegabyte,
 	)
-}
-
-func (r *ConsoleReporter) NewAccumulator(jobID string) *Accumulator {
-	if r == nil {
-		return nil
-	}
-
-	return newAccumulator(jobID, &r.data)
-}
-
-func (r *ConsoleReporter) ClearData() {
-	r.data.ClearData()
-}
-
-func (r *ConsoleReporter) SumBytesSent() uint64 {
-	return r.data.SumBytesSent()
 }

--- a/src/utils/metrics/stats.go
+++ b/src/utils/metrics/stats.go
@@ -1,0 +1,94 @@
+package metrics
+
+import (
+	"sort"
+
+	"go.uber.org/zap/zapcore"
+)
+
+type (
+	// Stat is the type of statistical metrics.
+	Stat int
+	// Stats contains all metrics packed as an array.
+	Stats [NumStats]uint64
+	// MultiStats contains multiple Stats as a slice. Useful for collecting Stats from coroutines.
+	MultiStats []Stats
+	// PerTargetStats is a map of Stats per target.
+	PerTargetStats map[string]Stats
+)
+
+const (
+	RequestsAttemptedStat Stat = iota
+	RequestsSentStat
+	ResponsesReceivedStat
+	BytesSentStat
+
+	NumStats
+)
+
+// String representation of the Stat.
+func (s Stat) String() string {
+	return [...]string{
+		"requests attempted",
+		"requests sent",
+		"responses received",
+		"bytes sent",
+	}[s]
+}
+
+// Sum up all Stats into a total Stats record.
+func (s MultiStats) Sum() Stats {
+	var res Stats
+
+	for i := range s {
+		for j := RequestsAttemptedStat; j < NumStats; j++ {
+			res[j] += s[i][j]
+		}
+	}
+
+	return res
+}
+
+func (ts PerTargetStats) sum(s Stat) uint64 {
+	var res uint64
+
+	for _, v := range ts {
+		res += v[s]
+	}
+
+	return res
+}
+
+func (ts PerTargetStats) sortedTargets() []string {
+	res := make([]string, 0, len(ts))
+	for k := range ts {
+		res = append(res, k)
+	}
+
+	sort.Strings(res)
+
+	return res
+}
+
+// MarshalLogObject is required to log PerTargetStats objects to zap
+func (ts PerTargetStats) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	for _, tgt := range ts.sortedTargets() {
+		tgtStats := ts[tgt]
+
+		if err := enc.AddObject(tgt, &tgtStats); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// MarshalLogObject is required to log Stats objects to zap
+func (stats *Stats) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddUint64("requests_attempted", stats[RequestsAttemptedStat])
+	enc.AddUint64("requests_sent", stats[RequestsSentStat])
+	enc.AddUint64("responses_received", stats[ResponsesReceivedStat])
+	enc.AddUint64("bytes_sent", stats[BytesSentStat])
+
+	return nil
+}


### PR DESCRIPTION
# Description

I want to improve it further to show a pretty summary like before. For this I split `Reporter` into several implementations - for zap and console.

 Also `simple` output format is made default now.

It's a work in progress - I intend to split `mectrics.go` into several files. But I hope it gives a preview of what's coming if somebody touches same files.

**P.S.** I intend to finish this somewhere around today's evening.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

if some scripts or bots use json as default now - we need to update those before releasing - the default becomes simple.

## How Has This Been Tested?

By running and looking at the output in a terminal.

## Test Configuration

- Release version: latest main branch (v0.8.31 is the latest current release)
- Platform: Mac OS

## Logs

Output sample (real values crossed out, truncated for shorter text, alignment in console is better)

```text
single http request     {"target": "https://sample/"}
single http request     {"target": "https://sample"}

 --- Traffic stats ---
 |                                Target | Requests attempted | Requests sent | Responses received | Data sent |
 |                  http://xx.xx.xx.xx |                  1 |                   0 |                  0 |     0.00 MB |
 |                  http://xx.xx.xx.xx |                  3 |                  0 |                  0 |     0.00 MB |
 |                        http://sample |                  2 |                  0 |                  0 |     0.00 MB |
 |                      https://sample |                  1 |                   0 |                  0 |     0.00 MB |
 |                                         --- |               --- |                --- |               --- |              --- |
 |                                      Total |   14623715 |    14620788 |           1490 | 139.66 MB |

loading config  {"path": "https://sample/config.json"}
the config has not changed. Keep calm and carry on!
```