### PR TITLE
Fix a crash when interface name is empty

### DIFF
--- a/src/utils/utils_unix.go
+++ b/src/utils/utils_unix.go
@@ -60,11 +60,16 @@ func getSockaddrByName(name string) syscall.Sockaddr {
 }
 
 func BindToInterface(name string) func(network, address string, conn syscall.RawConn) error {
+	sockAddr := getSockaddrByName(name)
+	if sockAddr == nil {
+		return nil
+	}
+
 	return func(network, address string, conn syscall.RawConn) error {
 		var operr error
 
 		if err := conn.Control(func(fd uintptr) {
-			operr = syscall.Bind(int(fd), getSockaddrByName(name))
+			operr = syscall.Bind(int(fd), sockAddr)
 		}); err != nil {
 			return err
 		}


### PR DESCRIPTION
# Description

Main's top crashes with lots of errors about dereferencing nil. Happens in Bind(). Because `getSockaddrByName()` can return `nil` in lots of cases. Not sure if I fixed it entirely correctly, but this is my take on it. Maybe instead of returning nil this route needs to evade something above when interface's name is empty.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Ran in my terminal

## Test Configuration

- Release version: main's top (latest release is .33)
- Platform: Mac OS

