### PR TITLE
Switch console log time format to RFC3339

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/Arriven/db1000n/src/job"
 	"github.com/Arriven/db1000n/src/job/config"
@@ -120,6 +121,10 @@ func newZapLogger(debug bool, logLevel string, logFormat string) (*zap.Logger, e
 		}
 	} else if logFormat != "" {
 		cfg.Encoding = logFormat
+
+		if logFormat == "console" {
+			cfg.EncoderConfig.EncodeTime = zapcore.RFC3339TimeEncoder
+		}
 	}
 
 	level, err := zap.ParseAtomicLevel(logLevel)


### PR DESCRIPTION
instead of default epoch floating time

# Description

This format should be more familiar for users. Why not ISO8601 - to my taste RFC3339 is a tad more readable. Although both formats are almost interchangeable.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

It  changes the existing `console` log format, some users might rely on epoch time.

## How Has This Been Tested?

Ran in my terminal, saw the output.

## Test Configuration

- Release version: latest main's top (latest release is .33)
- Platform: Mac OS

## Logs

After the change:
```text
2022-05-08T15:56:23+03:00       info    job/http.go:70  single http request     {"target": "https://sample"}
2022-05-08T15:56:23+03:00       info    job/http.go:70  single http request     {"target": "https://sample"}
```

