### PR TITLE
perf: add buffering in metrics table reporter

### DIFF
--- a/src/utils/metrics/reporter.go
+++ b/src/utils/metrics/reporter.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"text/tabwriter"
@@ -35,16 +36,24 @@ func (r *ZapReporter) WriteSummary(metrics *Metrics) {
 // ConsoleReporter
 
 type ConsoleReporter struct {
-	target io.Writer
+	target *bufio.Writer
 }
 
 // NewConsoleReporter creates a new Reporter which outputs straight to the console
 func NewConsoleReporter(target io.Writer) Reporter {
-	return &ConsoleReporter{target: target}
+	return &ConsoleReporter{target: bufio.NewWriter(target)}
 }
 
 func (r *ConsoleReporter) WriteSummary(metrics *Metrics) {
 	writer := tabwriter.NewWriter(r.target, 1, 1, 1, ' ', tabwriter.AlignRight)
+
+	r.writeSummaryTo(metrics, writer)
+
+	// Important to flush the remains of bufio.Writer
+	r.target.Flush()
+}
+
+func (r *ConsoleReporter) writeSummaryTo(metrics *Metrics, writer *tabwriter.Writer) {
 	stats, totals := metrics.SumAllStats()
 
 	defer writer.Flush()


### PR DESCRIPTION
Writing letter-by-letter is very inefficient.
On kinda slow machines, the whole table was printing in like 10 seconds word by word.
This commit prevents these write calls
because now, everything is added to a 4096-byte buffer and flushed in the end.
Multiple 1-byte write syscalls were made without buffering.

# Description

Added buffering in metrics reporter.

## Type of change

- [x] Faster logs


## Tested

- [x] Raspberry pi 4B


