### PR TITLE
Add `-less-stats` cmd param to group targets by protocols

### DIFF
--- a/src/utils/metrics/reporter.go
+++ b/src/utils/metrics/reporter.go
@@ -19,16 +19,17 @@ type Reporter interface {
 // ZapReporter
 
 type ZapReporter struct {
-	logger *zap.Logger
+	logger       *zap.Logger
+	groupTargets bool
 }
 
 // NewZapReporter creates a new Reporter using a zap logger.
-func NewZapReporter(logger *zap.Logger) Reporter {
-	return &ZapReporter{logger: logger}
+func NewZapReporter(logger *zap.Logger, groupTargets bool) Reporter {
+	return &ZapReporter{logger: logger, groupTargets: groupTargets}
 }
 
 func (r *ZapReporter) WriteSummary(metrics *Metrics) {
-	stats, totals := metrics.SumAllStats()
+	stats, totals := metrics.SumAllStats(r.groupTargets)
 
 	r.logger.Info("stats", zap.Object("total", &totals), zap.Object("targets", stats))
 }
@@ -36,12 +37,13 @@ func (r *ZapReporter) WriteSummary(metrics *Metrics) {
 // ConsoleReporter
 
 type ConsoleReporter struct {
-	target *bufio.Writer
+	target       *bufio.Writer
+	groupTargets bool
 }
 
 // NewConsoleReporter creates a new Reporter which outputs straight to the console
-func NewConsoleReporter(target io.Writer) Reporter {
-	return &ConsoleReporter{target: bufio.NewWriter(target)}
+func NewConsoleReporter(target io.Writer, groupTargets bool) Reporter {
+	return &ConsoleReporter{target: bufio.NewWriter(target), groupTargets: groupTargets}
 }
 
 func (r *ConsoleReporter) WriteSummary(metrics *Metrics) {
@@ -54,7 +56,7 @@ func (r *ConsoleReporter) WriteSummary(metrics *Metrics) {
 }
 
 func (r *ConsoleReporter) writeSummaryTo(metrics *Metrics, writer *tabwriter.Writer) {
-	stats, totals := metrics.SumAllStats()
+	stats, totals := metrics.SumAllStats(r.groupTargets)
 
 	defer writer.Flush()
 


### PR DESCRIPTION
# Description

Adds a cmd line parameter `-less-stats` to group all target stats by protocols. Currently the list of stats could be very long and it's not always convenient to observe.

Maybe "fewer" would be more grammatical, but I guess "less" is kinda more conventional for text and more widespread (think of `less` utility).

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Running in a terminal and observing the output.

## Test Configuration

- Release version: latest main (latest release is 0.9.8)
- Platform: Mac OS

## Logs

After the change with `-less-stats` supplied:
```text
 --- Traffic stats ---
 | Target | Requests attempted | Requests sent | Responses received | Data sent |
 |   http |               8707 |          2491 |               2491 |   0.41 MB |
 |  https |               8225 |          1051 |               1051 |   0.17 MB |
 |    tcp |              37952 |         37944 |                  0 |   0.36 MB |
 |    --- |                --- |           --- |                --- |       --- |
 |  Total |              54884 |         41486 |               3542 |   0.94 MB |
```
